### PR TITLE
added a new supported package uv

### DIFF
--- a/content/opensource_packages/uv.md
+++ b/content/opensource_packages/uv.md
@@ -5,14 +5,14 @@ description: uv is a cross-platform asynchronous I/O library written in C. It pr
 download_url: https://github.com/astral-sh/uv/releases
 works_on_arm: true
 supported_minimum_version:     
-  version_number: v0.4.26
-  release_date: 2024/10/23
+  version_number: v0.0.5
+  release_date: 2024/02/15
 optional_info:    
-  support_caveats: No known caveats.
+  support_caveats:
   getting_started_resources:        
     arm_content:
     partner_content:
     official_docs: https://github.com/astral-sh/uv
 optional_hidden_info:    
-  release_notes__supported_minimum: https://github.com/astral-sh/uv/releases/tag/0.4.26
+  release_notes__supported_minimum: https://github.com/astral-sh/uv/releases/tag/0.0.5
 ---


### PR DESCRIPTION

Adding uv package, which supports Arm (Aarch64). Tested and verified that it works on ARM64 Linux.

- [Yes] I want to participate in the Arm Cloud Software Scavenger Hunt Sweepstakes, and confirm I have read and agree to its [Terms and Conditions](https://www.arm.com/-/media/files/pdf/terms-and-conditions/arm-cloud-software-scavenger-hunt-terms-and-conditions).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
