### PR TITLE
Add 5G-RAL and Split-Python-SDK files

### DIFF
--- a/content/opensource_packages/5G-RAL.md
+++ b/content/opensource_packages/5G-RAL.md
@@ -1,0 +1,29 @@
+---
+name: 5G RAL (RAN Acceleration library)
+category: Networking
+description: Arm RAN Acceleration library (ArmRAL) implements common signal processing functions in 5G Radio Access Network using Arm Neoverse cores.
+download_url: https://git.gitlab.arm.com/networking/ral/-/releases
+works_on_arm: true
+supported_minimum_version:
+    version_number: 20.10
+    release_date: 2020/10/02
+
+
+optional_info:
+    homepage_url: https://developer.arm.com/documentation/102249/2410/Tutorials/Get-started-with-Arm-RAN-Acceleration-Library?lang=en
+    support_caveats:
+    alternative_options:
+    getting_started_resources:
+        arm_content: https://community.arm.com/arm-community-blogs/b/tools-software-ides-blog/posts/introducing-arm-ran-acceleration-library
+        partner_content:
+        official_docs: https://developer.arm.com/documentation/102249/2410/Tutorials/Use-Arm-RAN-Acceleration-Library?lang=en
+    arm_recommended_minimum_version:
+        version_number:
+        release_date:
+
+optional_hidden_info:
+    release_notes__supported_minimum: https://developer.arm.com/documentation/102249/2410?lang=en
+    release_notes__recommended_minimum:
+    other_info:
+
+---

--- a/content/opensource_packages/Split-Python-SDK.md
+++ b/content/opensource_packages/Split-Python-SDK.md
@@ -1,0 +1,29 @@
+---
+name: Split (Python SDK) Client
+category: Miscellaneous
+description: Split Python SDK works with Split, the platform for controlled rollouts, that serves features to the users via a Split feature flag to manage the complete customer experience.
+download_url: https://pypi.org/project/splitio-client/#history
+works_on_arm: true
+supported_minimum_version:
+    version_number: 0.0.1
+    release_date: 2016/06/14
+
+
+optional_info:
+    homepage_url: https://github.com/splitio/python-client
+    support_caveats:
+    alternative_options:
+    getting_started_resources:
+        arm_content:
+        partner_content:
+        official_docs: https://help.split.io/hc/en-us/articles/360020359652-Python-SDK
+    arm_recommended_minimum_version:
+        version_number:
+        release_date:
+
+optional_hidden_info:
+    release_notes__supported_minimum:
+    release_notes__recommended_minimum:
+    other_info: There are no Linux/ARM64 release notes. The first release on Pypi, i.e. 0.0.1, can be installed via pip on the Neoverse N1. Pypi contains platform-independent tars. Similar to python, there are SDKs available for Java and Go.
+
+---


### PR DESCRIPTION
1. Added 5G-RAL.md file.
2. Added Split-Python-SDK.md.

Signed-off-by: odidev [odidev@puresoftware.com](mailto:odidev@puresoftware.com)