### PR TITLE
Align Azul Zulu and Zing with correct branding names

### DIFF
--- a/content/commercial_packages/zing-enterprise-openjdk.md
+++ b/content/commercial_packages/zing-enterprise-openjdk.md
@@ -1,8 +1,8 @@
 ---
-name: Azul Platform Prime (with Zing)
+name: Azul Zing Builds of OpenJDK (Zing/Java)
 vendor: Azul
 category: Runtimes
-description: Azul Platform Prime contains Azul Zing, a commercial optimized build of OpenJDK. Suitable for applications needing low latency and low cost at scale. Key additions include the C4 Pauseless Garbage Collector and the Falcon JIT Compiler.   
+description: Azul Zing Builds of OpenJDK (Zing), a component of Azul Platform Prime, is a commercial optimized build of OpenJDK. Suitable for Java/JVM applications needing low latency and low cost at scale. Key additions include the C4 Pauseless Garbage Collector and the Falcon JIT Compiler.   
 product_url: https://www.azul.com/products/prime/
 works_on_arm: true
 release_date_on_arm: 2023/02/07

--- a/content/commercial_packages/zulu-enterprise-openjdk.md
+++ b/content/commercial_packages/zulu-enterprise-openjdk.md
@@ -1,8 +1,8 @@
 ---
-name: Zulu Enterprise JDK
+name: Azul Zulu Builds of OpenJDK (Zulu/Java)
 vendor: Azul
 category: Runtimes
-description: Azul Zulu Enterprise, also a component of Azul Platform Core, is designed with the certified builds, tight security, and cost efficiencies needed to run today’s business–critical, Java-based services.
+description: Azul Zulu Builds of OpenJDK (Zulu), a component of Azul Platform Core, is designed with the certified builds, tight security, and cost efficiencies needed to run today’s business–critical, Java/JVM-based services.
 product_url: https://www.azul.com/products/core/
 works_on_arm: true
 release_date_on_arm: 2014/04/08


### PR DESCRIPTION
Recently, the OpenJDK builds of Azul were renamed. This pull request aligns the two existing packages with the naming used on the Azul website and in the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
