### PR TITLE
Add information for the Recommended Versions

### DIFF
--- a/content/opensource_packages/5G-RAL.md
+++ b/content/opensource_packages/5G-RAL.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content:
         official_docs: https://developer.arm.com/documentation/102249/2410/Tutorials/Use-Arm-RAN-Acceleration-Library?lang=en
     arm_recommended_minimum_version:
-        version_number:
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 24.1
+        release_date: 2024/10/07
+        reference_content: https://gitlab.arm.com/networking/ral/-/releases/armral-24.10
+        rationale: In this release, armral_turbo_perm_idx_init was added for LTE Turbo permutation indices, and armral_turbo_decode_block/_noalloc was updated to optionally use a user-allocated buffer for improved performance. armral_cmplx_matmul_i16_noalloc was introduced for complex matrix multiplication without memory allocation. FFT routines armral_fft_execute_cf32 and _cs16 now use Bluestein's algorithm for faster computation in previously recursive cases.
 
 optional_hidden_info:
     release_notes__supported_minimum: https://developer.arm.com/documentation/102249/2410?lang=en

--- a/content/opensource_packages/libjpeg.md
+++ b/content/opensource_packages/libjpeg.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content:
         official_docs: https://libjpeg-turbo.org/Downloads/YUM
     arm_recommended_minimum_version:
-        version_number:
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 2.1.3
+        release_date: 2022/02/26
+        reference_content: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/tag/2.1.3
+        rationale: In this release, the build system now enables the intrinsics implementation of the Aarch64 NEON SIMD extensions by default when using GCC 12 or later.
 
 optional_hidden_info:
     release_notes__supported_minimum:

--- a/content/opensource_packages/submarine.md
+++ b/content/opensource_packages/submarine.md
@@ -18,10 +18,10 @@ optional_info:
         partner_content:
         official_docs: https://github.com/FyraLabs/submarine/tree/v0.1.0?tab=readme-ov-file#%EF%B8%8F-building
     arm_recommended_minimum_version:
-        version_number:
-        release_date:
-        reference_content:
-        rationale:
+        version_number: 0.3.0
+        release_date: 2024/12/30
+        reference_content: https://github.com/FyraLabs/submarine/releases/tag/v0.3.0
+        rationale: This release adds cross-compilation for Arm64 on GitHub runners, indicating active efforts toward Arm64 compatibility and increased confidence in Linux/Arm64 support.
 
 optional_hidden_info:
     release_notes__supported_minimum:


### PR DESCRIPTION
Updated the metadata for the recommended versions for the following packages:

1. 5G-RAL
2. Libjpeg-turbo
3. Submarine
