### PR TITLE
Add claude and codex

### DIFF
--- a/content/windows/all_packages/claude.md
+++ b/content/windows/all_packages/claude.md
@@ -2,7 +2,7 @@
 name: Claude Code
 category: AI/ML Tools
 description: Claude Code is an AI coding agent from Anthropic that is designed to perform software tasks such as writing code and fixing bugs.
-download_url: https://releases.llvm.org/
+download_url: https://claude.com/download
 works_on_arm: true
 supported_minimum_version:
   version_number: 2.1.0

--- a/content/windows/all_packages/claude.md
+++ b/content/windows/all_packages/claude.md
@@ -1,0 +1,31 @@
+---
+name: Claude Code
+category: AI/ML Tools
+description: Claude Code is an AI coding agent from Anthropic that is designed to perform software tasks such as writing code and fixing bugs.
+download_url: https://releases.llvm.org/
+works_on_arm: true
+supported_minimum_version:
+  version_number: 2.1.0
+  release_date: 2026/01/07
+
+
+optional_info:
+  homepage_url: https://claude.com/product/claude-code
+  support_caveats:
+  alternative_options:
+  getting_started_resources:
+    official_docs: https://code.claude.com/docs/en/overview
+    arm_content:
+    partner_content:
+  arm_recommended_minimum_version:
+    version_number:
+    release_date:
+    reference_content:
+    rationale:
+
+optional_hidden_info:
+  release_notes__supported_minimum:
+  release_notes__recommended_minimum:
+  other_info:
+
+---

--- a/content/windows/all_packages/codex.md
+++ b/content/windows/all_packages/codex.md
@@ -1,0 +1,28 @@
+---
+name: Codex
+category: AI/ML Tools
+description: Codex is an AI coding agent from OpenAI that is designed to perform software tasks such as writing code and fixing bugs.
+download_url: https://chatgpt.com/codex/
+works_on_arm: true
+supported_minimum_version:
+  version_number: 5.5
+  release_date: 2026/04/30
+
+optional_info:
+  homepage_url: https://chatgpt.com/codex/
+  support_caveats: null
+  alternative_options: null
+  arm_recommended_minimum_version:
+    version_number: null
+    release_date: null
+    reference_content: null
+    rationale: null
+  getting_started_resources:
+    official_docs: https://chatgpt.com/overview/
+    arm_content:
+    partner_content:
+optional_hidden_info:
+  release_notes__supported_minimum:
+  release_notes__recommended_minimum: null
+  other_info: null
+---


### PR DESCRIPTION
This change adds OpenAI's Codex and Anthropic's Claude Code to the list of Windows metadata.

Before submitting a pull request for one or more packages, please review the [Contribution Guidelines](https://github.com/ArmDeveloperEcosystem/ecosystem-dashboard-for-arm/blob/main/contrib.md).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the Creative Commons Attribution 4.0 International License. 
