### PR TITLE
Show skipped regression checks as not counted

### DIFF
--- a/themes/arm-design-system-hugo-theme/layouts/partials/package-display/row-sub.html
+++ b/themes/arm-design-system-hugo-theme/layouts/partials/package-display/row-sub.html
@@ -49,32 +49,22 @@
                     {{ $passed := int (default 0 $testData.tests.passed) }}
                     {{ $failed := int (default 0 $testData.tests.failed) }}
                     {{ $skipped := int (default 0 $testData.tests.skipped) }}
-                    {{ $total := 6 }}
-                    {{ $effectivePassed := $passed }}
                     {{ $regressionDecision := default "" $testData.metadata.regression_decision }}
                     {{ $regressionReason := default "" $testData.metadata.regression_reason }}
                     {{ $regressionApplicability := default "" $testData.metadata.regression_applicability }}
                     {{ $isPackageManagerSkip := or (eq $regressionDecision "not_applicable_package_manager") (and (eq $regressionApplicability "not_applicable") (eq $regressionReason "package_manager_installed")) }}
                     {{ $isCurrentLatestSkip := in (slice "no_newer_stable_available" "current_is_latest_stable" "pinned_is_latest" "already_current" "already_at_latest" "at_latest" "current_is_latest") $regressionDecision }}
-                    {{ $isSafeRegressionSkip := or $isPackageManagerSkip $isCurrentLatestSkip }}
                     {{ $deferredRegressionDecisions := slice "manual_review_needed" "metadata_review_required" "hold_current_arm_dependency_gap" "not_configured" "applicable_deferred" "runtime_validation_not_automated" "bounded_runtime_deferred" "arm64_desktop_artifact_unavailable" }}
                     {{ $testRunURL := default "" $testData.run.url }}
 
-                    {{ if and $isSafeRegressionSkip (eq $failed 0) (lt $effectivePassed $total) }}
-                        {{ $effectivePassed = add $effectivePassed 1 }}
-                    {{ end }}
-                    {{ if gt $effectivePassed $total }}
-                        {{ $effectivePassed = $total }}
-                    {{ end }}
-
-                    {{ $badgeDenominator := $effectivePassed }}
+                    {{ $badgeDenominator := $passed }}
                     {{ if gt $failed 0 }}
                         {{ $badgeDenominator = add $passed $failed }}
                     {{ end }}
                     {{ $badgeText := "0 passing" }}
                     {{ $badgeColor := "#dc3545" }}
-                    {{ if gt $effectivePassed 0 }}
-                        {{ $badgeText = printf "%v/%v passing" $effectivePassed $badgeDenominator }}
+                    {{ if gt $passed 0 }}
+                        {{ $badgeText = printf "%v/%v passing" $passed $badgeDenominator }}
                         {{ if eq $failed 0 }}
                             {{ $badgeColor = "#28a745" }}
                         {{ end }}


### PR DESCRIPTION
## Summary
- Update Arm64 test badge display so skipped/deferred/not-applicable regression checks are not counted as passed
- Preserve dropdown details so Test 6 still shows its actual skipped/deferred/not-applicable state
- Keeps successful packages green when baseline checks pass, while showing examples like AvxToNeon as 5/5 instead of 6/6

## Validation
- Ran `hugo --gc --minify`
- Verified AvxToNeon renders as `5/5 passing`
- Verified display counts from current result data: 914 expected `6/6 passing`, 47 expected `5/5 passing`, 0 red badges