### PR TITLE
Add FastCGI and Libgpg-error

### DIFF
--- a/content/linux/opensource_packages/fastcgi.md
+++ b/content/linux/opensource_packages/fastcgi.md
@@ -1,0 +1,31 @@
+---
+name: FastCGI
+category: Web Server
+description: FastCGI is a language-independent protocol that improves web application performance by running external applications as persistent processes, enabling efficient communication with web servers.
+download_url: https://github.com/FastCGI-Archives/fcgi2/tags
+works_on_arm: true
+supported_minimum_version:
+    version_number: 2.4.2
+    release_date: 2019/02/19
+ 
+ 
+optional_info:
+    homepage_url: https://github.com/FastCGI-Archives/fcgi2
+    support_caveats:
+    alternative_options:
+    getting_started_resources:
+        official_docs: https://github.com/FastCGI-Archives/fcgi2#basic-directions
+        arm_content:
+        partner_content:
+    arm_recommended_minimum_version:
+        version_number:
+        release_date:
+        reference_content:
+        rationale:
+ 
+optional_hidden_info:
+    release_notes__supported_minimum:
+    release_notes__recommended_minimum:
+    other_info: Release notes for the initial Linux/Arm64 support are not available. FastCGI version 2.4.2 can be built from source for Linux/Arm64.
+ 
+---

--- a/content/linux/opensource_packages/libgpg-error.md
+++ b/content/linux/opensource_packages/libgpg-error.md
@@ -1,0 +1,31 @@
+---
+name: Libgpg-error
+category: Crypto
+description: Libgpg-error is a library that provides common error codes, utility functions, and basic support features shared across GnuPG components.
+download_url: https://github.com/gpg/libgpg-error/tags
+works_on_arm: true
+supported_minimum_version:
+    version_number: 1.21
+    release_date: 2015/12/12
+ 
+ 
+optional_info:
+    homepage_url: https://github.com/gpg/libgpg-error
+    support_caveats:
+    alternative_options:
+    getting_started_resources:
+        official_docs: https://github.com/gpg/libgpg-error/blob/master/INSTALL
+        arm_content:
+        partner_content:
+    arm_recommended_minimum_version:
+        version_number:
+        release_date:
+        reference_content:
+        rationale:
+ 
+optional_hidden_info:
+    release_notes__supported_minimum:
+    release_notes__recommended_minimum:
+    other_info: Package can be installed for Arm via "apt install libgpg-error-dev". Minimum version corresponds to Ubuntu Xenial is 1.21. Kindly refer [this](https://launchpad.net/ubuntu/xenial/arm64/libgpg-error-dev).
+ 
+---


### PR DESCRIPTION
1. Added content/linux/opensource_packages/fastcgi.md file.
2. Added content/linux/opensource_packages/libgpg-error.md file.

Signed-off-by: odidev [odidev@puresoftware.com](mailto:odidev@puresoftware.com)