### PR TITLE
Fix weekly orchestrator smoke run blockers

### DIFF
--- a/.github/actions/apt-bootstrap/action.yml
+++ b/.github/actions/apt-bootstrap/action.yml
@@ -30,12 +30,23 @@ inputs:
     description: Install packages with --no-install-recommends when set to true.
     required: false
     default: "false"
+  update_timeout_seconds:
+    description: Maximum seconds to allow each apt-get update attempt before retrying.
+    required: false
+    default: "600"
+  install_timeout_seconds:
+    description: Maximum seconds to allow each apt-get install attempt before retrying.
+    required: false
+    default: "1800"
 
 runs:
   using: composite
   steps:
     - name: Harden apt update and install
       shell: bash
+      env:
+        APT_UPDATE_TIMEOUT_SECONDS: ${{ inputs.update_timeout_seconds }}
+        APT_INSTALL_TIMEOUT_SECONDS: ${{ inputs.install_timeout_seconds }}
       run: |
         set -euo pipefail
         bash "${{ github.action_path }}/bootstrap.sh" \

--- a/.github/actions/apt-bootstrap/bootstrap.sh
+++ b/.github/actions/apt-bootstrap/bootstrap.sh
@@ -8,6 +8,8 @@ INITIAL_BACKOFF_SECONDS=5
 QUIET=false
 UPDATE_ONLY=false
 NO_INSTALL_RECOMMENDS=false
+APT_UPDATE_TIMEOUT_SECONDS="${APT_UPDATE_TIMEOUT_SECONDS:-600}"
+APT_INSTALL_TIMEOUT_SECONDS="${APT_INSTALL_TIMEOUT_SECONDS:-1800}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -50,6 +52,10 @@ apt_update() {
   sudo apt-get clean
   sudo rm -rf /var/lib/apt/lists/*
   local cmd=(
+    timeout
+    --signal=TERM
+    --kill-after=60s
+    "${APT_UPDATE_TIMEOUT_SECONDS}s"
     sudo apt-get
     -o Acquire::Retries=3
     -o Acquire::http::No-Cache=true
@@ -91,6 +97,10 @@ fi
 
 read -r -a package_array <<< "$FULL_PACKAGES"
 install_cmd=(
+  timeout
+  --signal=TERM
+  --kill-after=60s
+  "${APT_INSTALL_TIMEOUT_SECONDS}s"
   sudo env
   DEBIAN_FRONTEND=noninteractive
   APT_LISTCHANGES_FRONTEND=none

--- a/.github/workflows/test-activemq.yml
+++ b/.github/workflows/test-activemq.yml
@@ -113,14 +113,10 @@ jobs:
       - name: Install ActiveMQ
         id: install
         run: |
-          set -e
+          set -euo pipefail
           echo "Installing ActiveMQ from Ubuntu packages..."
 
-          sudo apt-get update
-          # Install Java + ActiveMQ (classic)
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            default-jre-headless \
-            activemq
+          bash .github/actions/apt-bootstrap/bootstrap.sh --packages "default-jre-headless activemq"
 
           # Find activemq binary
           ACTIVEMQ_BIN=$(command -v activemq || dpkg -L activemq | grep '/bin/activemq$' | head -1 || true)
@@ -377,4 +373,3 @@ jobs:
           echo "3. Check 'activemq --help' output: ${{ steps.test3.outputs.status || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "4. Check Java dependency: ${{ steps.test4.outputs.status || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
           echo "5. Check ActiveMQ has configuration files under /etc: ${{ steps.test5.outputs.status || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
-

--- a/.github/workflows/test-activemq.yml
+++ b/.github/workflows/test-activemq.yml
@@ -1,6 +1,7 @@
 name: Test ActiveMQ on Arm64
 
 on:
+  workflow_dispatch:
   workflow_call:
     outputs:
       contract_version:

--- a/.github/workflows/test-java-openjdk.yml
+++ b/.github/workflows/test-java-openjdk.yml
@@ -142,10 +142,10 @@ jobs:
       - name: Install Java/OpenJDK
         id: install
         run: |
+          set -euo pipefail
           echo "Installing OpenJDK 17..."
           
-          sudo apt-get update
-          if sudo apt-get install -y openjdk-17-jdk; then
+          if bash .github/actions/apt-bootstrap/bootstrap.sh --packages "openjdk-17-jdk"; then
             echo "OpenJDK installed successfully"
             echo "install_status=success" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/test-wireshark.yml
+++ b/.github/workflows/test-wireshark.yml
@@ -80,7 +80,7 @@ jobs:
   test-wireshark:
     runs-on: ubuntu-24.04-arm
     env:
-      WIRESHARK_VERSION: "4.6.3"
+      WIRESHARK_VERSION: "4.6.6"
 
     outputs:
       contract_version: "2.0"
@@ -123,38 +123,7 @@ jobs:
         id: install
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
-            build-essential \
-            cmake \
-            ninja-build \
-            flex \
-            bison \
-            curl \
-            python3-dev \
-            qt6-base-dev \
-            qt6-tools-dev \
-            qt6-multimedia-dev \
-            libbrotli-dev \
-            libc-ares-dev \
-            libcap-dev \
-            libgcrypt20-dev \
-            libglib2.0-dev \
-            libgnutls28-dev \
-            libkrb5-dev \
-            liblua5.4-dev \
-            libmaxminddb-dev \
-            libminizip-dev \
-            libnghttp2-dev \
-            libnl-3-dev \
-            libnl-genl-3-dev \
-            libpcap-dev \
-            libsbc-dev \
-            libsnappy-dev \
-            libspeexdsp-dev \
-            libssh-gcrypt-dev \
-            libsystemd-dev \
-            libxml2-dev
+          bash .github/actions/apt-bootstrap/bootstrap.sh --packages "build-essential cmake ninja-build flex bison curl python3-dev qt6-base-dev qt6-tools-dev qt6-multimedia-dev libbrotli-dev libc-ares-dev libcap-dev libgcrypt20-dev libglib2.0-dev libgnutls28-dev libkrb5-dev liblua5.4-dev libmaxminddb-dev libminizip-dev libnghttp2-dev libnl-3-dev libnl-genl-3-dev libpcap-dev libsbc-dev libsnappy-dev libspeexdsp-dev libssh-gcrypt-dev libsystemd-dev libxml2-dev"
 
           BASE_DIR="${RUNNER_TEMP}/wireshark-current"
           rm -rf "$BASE_DIR"


### PR DESCRIPTION
## Summary
- update Wireshark baseline to the currently published 4.6.6 source tarball
- route Wireshark, ActiveMQ, and Java/OpenJDK apt setup through the hardened apt bootstrap
- add apt update/install timeouts to prevent six-hour hangs in weekly orchestrator runs

## Validation
- bash -n .github/actions/apt-bootstrap/bootstrap.sh
- git diff --check
- parsed changed YAML files with PyYAML
- verified Wireshark 4.6.6 source URL returns HTTP 200

## Notes
After merge, run the full smoke-test orchestrator on main to refresh production-ready results.