### PR TITLE
Fix spaCy smoke install on Arm64

### DIFF
--- a/.github/workflows/test-spacy.yml
+++ b/.github/workflows/test-spacy.yml
@@ -79,6 +79,9 @@ jobs:
     permissions:
       contents: read
       actions: read
+    env:
+      SPACY_VERSION: "3.8.14"
+      NUMPY_CONSTRAINT: "numpy<2.0"
 
     outputs:
       contract_version: "2.0"
@@ -121,9 +124,14 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install spacy
+          python -m pip install "$NUMPY_CONSTRAINT" "spacy==${SPACY_VERSION}"
+          python -m pip check
           echo "$PWD/venv/bin" >> "$GITHUB_PATH"
-          if python -c "import spacy" >/dev/null 2>&1; then
+          if python - <<'PY'
+          import spacy
+          print(f"spaCy import OK: {spacy.__version__}")
+          PY
+          then
             echo "install_status=success" >> "$GITHUB_OUTPUT"
           else
             echo "install_status=failed" >> "$GITHUB_OUTPUT"
@@ -142,7 +150,7 @@ jobs:
         continue-on-error: true
         run: |
           START_TIME=$(date +%s)
-          if python -c "import spacy" >/dev/null 2>&1; then
+          if python -c "import spacy; print('spaCy import OK')"; then
             echo "status=passed" >> "$GITHUB_OUTPUT"
           else
             echo "status=failed" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-spacy.yml
+++ b/.github/workflows/test-spacy.yml
@@ -82,6 +82,7 @@ jobs:
     env:
       SPACY_VERSION: "3.8.14"
       NUMPY_CONSTRAINT: "numpy<2.0"
+      CLICK_CONSTRAINT: "click<9"
 
     outputs:
       contract_version: "2.0"
@@ -124,7 +125,7 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install "$NUMPY_CONSTRAINT" "spacy==${SPACY_VERSION}"
+          python -m pip install "$NUMPY_CONSTRAINT" "$CLICK_CONSTRAINT" "spacy==${SPACY_VERSION}"
           python -m pip check
           echo "$PWD/venv/bin" >> "$GITHUB_PATH"
           if python - <<'PY'


### PR DESCRIPTION
## Summary
- Pin spaCy to 3.8.14 with compatible NumPy and Click constraints for the Arm64 smoke workflow
- Keep the import/CLI/functionality checks real and expose import tracebacks instead of hiding them

## Validation
- Targeted workflow passed: Test spaCy on Arm64, run 26653625660
- YAML parse and git diff whitespace checks passed