### PR TITLE
Harden Valgrind latest release lookup

### DIFF
--- a/.github/workflows/test-valgrind.yml
+++ b/.github/workflows/test-valgrind.yml
@@ -149,13 +149,16 @@ jobs:
           set -euo pipefail
           BASE_PREFIX="${{ steps.install.outputs.base_prefix }}"
           VERSION=$("${BASE_PREFIX}/bin/valgrind" --version 2>&1 | sed 's/^valgrind-//')
-          LATEST="$(
-            curl -fsSL https://sourceware.org/pub/valgrind/ \
+          RELEASE_INDEX=""
+          if ! RELEASE_INDEX="$(curl --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 --max-time 180 -fsSL https://sourceware.org/pub/valgrind/)"; then
+            echo "Sourceware Valgrind directory index fetch failed; falling back to sha512.sum."
+            RELEASE_INDEX="$(curl --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 20 --max-time 180 -fsSL https://sourceware.org/pub/valgrind/sha512.sum)"
+          fi
+          LATEST="$(printf '%s\n' "$RELEASE_INDEX" \
             | grep -oE 'valgrind-[0-9]+\.[0-9]+\.[0-9]+\.tar\.bz2' \
             | sed 's/^valgrind-//; s/\.tar\.bz2$//' \
-            | sort -V \
-            | tail -n 1
-          )"
+            | sort -Vu \
+            | tail -n 1)"
 
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "latest=${LATEST}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- retry Sourceware Valgrind directory index fetches
- fall back to sha512.sum when the directory index returns transient 5xx errors

## Validation
- ruby YAML parse for test-valgrind.yml
- actionlint with shellcheck disabled for test-valgrind.yml
- git diff --check