### PR TITLE
Prefer current Apache mirror for Accumulo regression download

### DIFF
--- a/.github/workflows/test-accumulo.yml
+++ b/.github/workflows/test-accumulo.yml
@@ -381,10 +381,14 @@ jobs:
 
           NEXT_TGZ=$(mktemp /tmp/accumulo-next-XXXXXX.tar.gz)
           NEXT_DIR=$(mktemp -d)
+          NEXT_DLCDN_URL="https://dlcdn.apache.org/accumulo/${NEXT_VERSION}/accumulo-${NEXT_VERSION}-bin.tar.gz"
+          NEXT_ARCHIVE_URL="https://archive.apache.org/dist/accumulo/${NEXT_VERSION}/accumulo-${NEXT_VERSION}-bin.tar.gz"
+          NEXT_DOWNLOADS_URL="https://downloads.apache.org/accumulo/${NEXT_VERSION}/accumulo-${NEXT_VERSION}-bin.tar.gz"
           if bash .github/scripts/download-with-fallback.sh \
               "$NEXT_TGZ" \
-              "https://archive.apache.org/dist/accumulo/${NEXT_VERSION}/accumulo-${NEXT_VERSION}-bin.tar.gz" \
-              "https://downloads.apache.org/accumulo/${NEXT_VERSION}/accumulo-${NEXT_VERSION}-bin.tar.gz"; then
+              "$NEXT_DLCDN_URL" \
+              "$NEXT_ARCHIVE_URL" \
+              "$NEXT_DOWNLOADS_URL"; then
             NEXT_EXTRACTED_ROOT=$(tar -tzf "$NEXT_TGZ" | head -1 | cut -d/ -f1 || true)
             tar -xzf "$NEXT_TGZ" -C "$NEXT_DIR"
             NEXT_HOME="$NEXT_DIR/${NEXT_EXTRACTED_ROOT}"


### PR DESCRIPTION
## Summary
- Try the current Apache dlcdn mirror before archive/downloads mirrors for Accumulo Test 6 candidate binary downloads.
- Keep the existing archive and downloads endpoints as fallbacks.

## Validation
- ruby YAML parse for test-accumulo.yml
- actionlint -shellcheck= .github/workflows/test-accumulo.yml
- git diff --check