### PR TITLE
Wait for Keycloak HTTP readiness

### DIFF
--- a/.github/workflows/test-keycloak.yml
+++ b/.github/workflows/test-keycloak.yml
@@ -264,20 +264,35 @@ jobs:
           START_TIME=$(date +%s)
           # Functional Validation
           
-          # Check if we get a response from localhost:8080
-          if curl -s -I http://localhost:8080 | grep -q "200 OK" || curl -s -I http://localhost:8080 | grep -q "302 Found"; then
-             echo "✓ Keycloak HTTP check passed"
-             echo "status=passed" >> $GITHUB_OUTPUT
-          else
-             echo "✗ Keycloak HTTP check failed"
-             # It might take longer or need specific path
-             if curl -s http://localhost:8080 | grep -q "Keycloak"; then
-                echo "✓ Keycloak content check passed"
-                echo "status=passed" >> $GITHUB_OUTPUT
-            else
-                echo "status=failed" >> $GITHUB_OUTPUT
-                exit 1
+          HTTP_READY=false
+          ROOT_STATUS="000"
+          REALM_STATUS="000"
+
+          for attempt in $(seq 1 60); do
+            ROOT_STATUS=$(curl -s -o /tmp/keycloak-root.out -w "%{http_code}" --max-time 5 http://localhost:8080/ || true)
+            REALM_STATUS=$(curl -s -o /tmp/keycloak-realm.out -w "%{http_code}" --max-time 5 http://localhost:8080/realms/master/.well-known/openid-configuration || true)
+
+            if [ "$ROOT_STATUS" = "200" ] || [ "$ROOT_STATUS" = "302" ] || [ "$ROOT_STATUS" = "303" ] || \
+               grep -qi "Keycloak" /tmp/keycloak-root.out || \
+               { [ "$REALM_STATUS" = "200" ] && grep -qi '"issuer"' /tmp/keycloak-realm.out; }; then
+              HTTP_READY=true
+              break
             fi
+
+            echo "Waiting for Keycloak HTTP readiness (attempt ${attempt}/60, root=${ROOT_STATUS}, realm=${REALM_STATUS})"
+            sleep 2
+          done
+
+          if [ "$HTTP_READY" = "true" ]; then
+            echo "✓ Keycloak HTTP check passed"
+            echo "status=passed" >> $GITHUB_OUTPUT
+          else
+            echo "✗ Keycloak HTTP check failed after waiting"
+            echo "Last root status: ${ROOT_STATUS}"
+            echo "Last realm status: ${REALM_STATUS}"
+            tail -n 120 keycloak.log || true
+            echo "status=failed" >> $GITHUB_OUTPUT
+            exit 1
           fi
           
           # Architecture Verification


### PR DESCRIPTION
## Summary
- Replace Keycloak Test 5's one-shot localhost curl with a bounded readiness loop.
- Probe both the root URL and the master realm discovery endpoint, and print server logs if readiness never arrives.

## Validation
- ruby YAML parse for test-keycloak.yml
- actionlint -shellcheck= .github/workflows/test-keycloak.yml
- git diff --check