### PR TITLE
Add generated data publisher foundation

### DIFF
--- a/.github/actions/publish-generated-data-pr/.gitignore
+++ b/.github/actions/publish-generated-data-pr/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/.github/actions/publish-generated-data-pr/README.md
+++ b/.github/actions/publish-generated-data-pr/README.md
@@ -1,0 +1,82 @@
+# Generated-data review publisher
+
+This composite action publishes allowlisted generated files to one
+automation-owned draft pull request. It never writes the reviewed base branch
+directly, approves a workflow, merges a pull request, or deploys content.
+
+## Foundation status
+
+This directory is a behavior-neutral publisher foundation. No existing
+production workflow invokes it, and adding it does not change repository
+permissions, rules, environments, secrets, or deployment behavior. A later,
+separately reviewed integration must supply credentials and wire the action into
+an isolated publisher job.
+
+## Candidate boundary
+
+The caller supplies exact files or directory prefixes through `paths`. Before
+creating a commit, the publisher verifies that every Git-visible dirty or
+untracked path is inside that allowlist. Existing and newly generated files must
+be regular files reached without symlinks. Callers can use
+`required-tracked-paths` for exact outputs that must already be tracked regular
+files and must remain tracked regular files after generation.
+
+The publisher binds generation to one base commit, validates every open pull
+request using the deterministic automation head regardless of its current base,
+and refuses to update the branch when pull-request or branch ownership is
+ambiguous. Branch replacement uses an exact `--force-with-lease` compare-and-swap.
+
+## Credential modes
+
+The action reads the actual API credential from the caller's `GH_TOKEN`
+environment variable. It does not accept a token as an action input and does not
+mint credentials. Two validated metadata inputs bind the expected PR identity to
+the selected credential mode:
+
+- `credential-source: github-token` is the default and requires
+  `expected-pr-author-login: github-actions[bot]`.
+- `credential-source: github-app` requires the login of the installed App bot,
+  such as `arm-ecosystem-publisher[bot]`.
+
+PR author comparisons are case-insensitive because GitHub logins are
+case-insensitive. Malformed logins, unknown credential modes, and incompatible
+source/author pairs fail closed. Changing credential modes while an existing
+deterministic PR is open also fails ownership validation because a PR's author is
+immutable.
+
+The PR body records the selected credential mode and expected author. In App
+mode it describes only the short-lived GitHub App installation token; it does not
+claim that the built-in workflow token created the PR.
+
+## Isolated publisher job
+
+Generation and publication should be separate jobs. The generator should run
+with `contents: read`, produce a bounded artifact, and receive no write token.
+The publisher job should:
+
+1. Check out the exact reviewed base SHA with persisted checkout credentials
+   disabled.
+2. Download and validate only the expected generated artifact.
+3. Receive one short-lived credential in `GH_TOKEN`.
+4. Invoke this action with an exact path allowlist, base SHA, credential source,
+   and expected PR author.
+5. Expose no deployment credentials and perform no deployment work.
+
+For the built-in token, grant `contents: write` and `pull-requests: write` only to
+that publisher job. For a GitHub App, keep the workflow token read-only and scope
+the App installation to this repository with only metadata read, contents
+read/write, pull requests read/write, and workflows read/write when the generated
+allowlist includes `.github/workflows/`. The App-token minting step and every
+external action must be pinned to reviewed commit SHAs.
+
+## Review and deployment gate
+
+A run that creates, updates, preserves, or closes a generated-data draft must not
+deploy. After the independently reviewed pull request is merged, a clean rerun
+against the merged base may return `no_changes`; deployment remains a separate
+workflow concern.
+
+Before any future production integration, repository owners must independently
+configure required approving reviews, required checks, administrator enforcement,
+a read-only default workflow token, and a protected production environment. This
+foundation does not activate or satisfy any of those controls.

--- a/.github/actions/publish-generated-data-pr/action.yml
+++ b/.github/actions/publish-generated-data-pr/action.yml
@@ -1,0 +1,67 @@
+name: Publish generated data review PR
+description: Publish an allowlisted generated-data change through one deterministic review PR.
+
+inputs:
+  producer:
+    description: Stable lowercase producer identity.
+    required: true
+  base-branch:
+    description: Exact branch reviewed by the generator.
+    required: true
+  expected-base-sha:
+    description: Exact base commit used to generate the data.
+    required: true
+  head-branch:
+    description: Stable automation-owned branch used for this producer and base.
+    required: true
+  title:
+    description: Pull request title.
+    required: true
+  commit-message:
+    description: Generated-data commit subject.
+    required: true
+  paths:
+    description: Newline-delimited exact files or directory prefixes ending in a slash.
+    required: true
+  required-tracked-paths:
+    description: Newline-delimited exact allowlisted files that must remain tracked regular files.
+    required: false
+    default: ""
+  expected-pr-author-login:
+    description: Exact GitHub login expected to own the generated pull request.
+    required: false
+    default: github-actions[bot]
+  credential-source:
+    description: Credential mode used through GH_TOKEN; github-token or github-app.
+    required: false
+    default: github-token
+
+outputs:
+  status:
+    description: created, updated, unchanged, no_changes, or closed_stale; only no_changes is deployable.
+    value: ${{ steps.publish.outputs.status }}
+  pr-url:
+    description: Exact review pull request URL, when one remains open.
+    value: ${{ steps.publish.outputs.pr_url }}
+  head-sha:
+    description: Exact generated-data branch head, when generated changes exist.
+    value: ${{ steps.publish.outputs.head_sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Publish deterministic generated-data review
+      id: publish
+      env:
+        GENERATED_DATA_BASE_BRANCH: ${{ inputs.base-branch }}
+        GENERATED_DATA_COMMIT_MESSAGE: ${{ inputs.commit-message }}
+        GENERATED_DATA_EXPECTED_BASE_SHA: ${{ inputs.expected-base-sha }}
+        GENERATED_DATA_EXPECTED_PR_AUTHOR_LOGIN: ${{ inputs.expected-pr-author-login }}
+        GENERATED_DATA_HEAD_BRANCH: ${{ inputs.head-branch }}
+        GENERATED_DATA_PATHS: ${{ inputs.paths }}
+        GENERATED_DATA_PRODUCER: ${{ inputs.producer }}
+        GENERATED_DATA_REQUIRED_TRACKED_PATHS: ${{ inputs.required-tracked-paths }}
+        GENERATED_DATA_TITLE: ${{ inputs.title }}
+        GENERATED_DATA_CREDENTIAL_SOURCE: ${{ inputs.credential-source }}
+      shell: bash
+      run: python3 "$GITHUB_ACTION_PATH/generated_data_pr.py"

--- a/.github/actions/publish-generated-data-pr/generated_data_pr.py
+++ b/.github/actions/publish-generated-data-pr/generated_data_pr.py
@@ -1,0 +1,1202 @@
+#!/usr/bin/env python3
+"""Publish allowlisted generated data through one automation-owned review PR."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import stat
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Protocol, Sequence
+from urllib.parse import urlencode, urlsplit
+
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+_PRODUCER_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+_REPOSITORY_RE = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}/[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$"
+)
+_BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,239}$")
+_PR_AUTHOR_LOGIN_RE = re.compile(
+    r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,98}[A-Za-z0-9])?(?:\[bot\])?$"
+)
+_AUTOMATION_PREFIX = "automation/generated-data/"
+_MARKER_VERSION = "v1"
+_DEFAULT_PR_AUTHOR_LOGIN = "github-actions[bot]"
+_CREDENTIAL_SOURCE_GITHUB_TOKEN = "github-token"
+_CREDENTIAL_SOURCE_GITHUB_APP = "github-app"
+_CREDENTIAL_SOURCES = frozenset(
+    {_CREDENTIAL_SOURCE_GITHUB_TOKEN, _CREDENTIAL_SOURCE_GITHUB_APP}
+)
+_TRAILER_PRODUCER = "Generated-Data-Producer"
+_TRAILER_BRANCH = "Generated-Data-Branch"
+_TRAILER_BASE_BRANCH = "Generated-Data-Base-Branch"
+_TRAILER_BASE_SHA = "Generated-Data-Base-SHA"
+
+
+class PublishError(RuntimeError):
+    """The generated-data transaction cannot proceed safely."""
+
+
+@dataclass(frozen=True)
+class Config:
+    producer: str
+    base_branch: str
+    expected_base_sha: str
+    head_branch: str
+    title: str
+    commit_message: str
+    paths: tuple[str, ...]
+    required_tracked_paths: tuple[str, ...]
+    repository: str
+    server_url: str
+    run_url: str
+    output_path: Path | None
+    expected_pr_author_login: str = _DEFAULT_PR_AUTHOR_LOGIN
+    credential_source: str = _CREDENTIAL_SOURCE_GITHUB_TOKEN
+
+    @classmethod
+    def from_environment(cls, environment: Mapping[str, str]) -> Config:
+        required = {
+            "producer": "GENERATED_DATA_PRODUCER",
+            "base_branch": "GENERATED_DATA_BASE_BRANCH",
+            "expected_base_sha": "GENERATED_DATA_EXPECTED_BASE_SHA",
+            "head_branch": "GENERATED_DATA_HEAD_BRANCH",
+            "title": "GENERATED_DATA_TITLE",
+            "commit_message": "GENERATED_DATA_COMMIT_MESSAGE",
+            "repository": "GITHUB_REPOSITORY",
+        }
+        values: dict[str, str] = {}
+        for field, variable in required.items():
+            value = environment.get(variable, "").strip()
+            if not value:
+                raise PublishError(f"{variable} is required")
+            values[field] = value
+
+        paths = _parse_path_list(environment.get("GENERATED_DATA_PATHS", ""))
+        required_tracked_paths = _parse_path_list(
+            environment.get("GENERATED_DATA_REQUIRED_TRACKED_PATHS", "")
+        )
+        server_url = environment.get("GITHUB_SERVER_URL", "https://github.com").rstrip("/")
+        run_id = environment.get("GITHUB_RUN_ID", "").strip()
+        run_url = (
+            f"{server_url}/{values['repository']}/actions/runs/{run_id}"
+            if run_id
+            else f"{server_url}/{values['repository']}/actions"
+        )
+        output = environment.get("GITHUB_OUTPUT", "").strip()
+        expected_pr_author_login = environment.get(
+            "GENERATED_DATA_EXPECTED_PR_AUTHOR_LOGIN",
+            _DEFAULT_PR_AUTHOR_LOGIN,
+        )
+        credential_source = environment.get(
+            "GENERATED_DATA_CREDENTIAL_SOURCE",
+            _CREDENTIAL_SOURCE_GITHUB_TOKEN,
+        )
+        config = cls(
+            producer=values["producer"],
+            base_branch=values["base_branch"],
+            expected_base_sha=values["expected_base_sha"],
+            head_branch=values["head_branch"],
+            title=values["title"],
+            commit_message=values["commit_message"],
+            paths=paths,
+            required_tracked_paths=required_tracked_paths,
+            repository=values["repository"],
+            server_url=server_url,
+            run_url=run_url,
+            output_path=Path(output) if output else None,
+            expected_pr_author_login=expected_pr_author_login,
+            credential_source=credential_source,
+        )
+        config.validate()
+        ref_name = environment.get("GITHUB_REF_NAME", "").strip()
+        if ref_name and ref_name != config.base_branch:
+            raise PublishError("base branch does not match GITHUB_REF_NAME")
+        return config
+
+    def validate(self) -> None:
+        if not _PRODUCER_RE.fullmatch(self.producer):
+            raise PublishError("producer must be a canonical lowercase slug")
+        if not _SHA_RE.fullmatch(self.expected_base_sha):
+            raise PublishError("expected base SHA must be a full lowercase Git commit")
+        if not _REPOSITORY_RE.fullmatch(self.repository):
+            raise PublishError("GITHUB_REPOSITORY is malformed")
+        server = urlsplit(self.server_url)
+        if (
+            server.scheme != "https"
+            or not server.netloc
+            or server.username is not None
+            or server.password is not None
+            or server.path not in {"", "/"}
+            or server.query
+            or server.fragment
+            or self.server_url.endswith("/")
+        ):
+            raise PublishError("GITHUB_SERVER_URL must be a canonical HTTPS origin")
+        _validate_branch(self.base_branch, "base branch")
+        _validate_branch(self.head_branch, "head branch")
+        expected_prefix = f"{_AUTOMATION_PREFIX}{self.producer}/"
+        if not self.head_branch.startswith(expected_prefix):
+            raise PublishError(
+                f"head branch must be under the producer namespace {expected_prefix!r}"
+            )
+        if self.head_branch == self.base_branch:
+            raise PublishError("generated-data head branch must differ from its base")
+        _validate_single_line(self.title, "title", maximum=200)
+        _validate_single_line(self.commit_message, "commit message", maximum=200)
+        _validate_pr_credentials(
+            self.expected_pr_author_login,
+            self.credential_source,
+        )
+        if not self.paths:
+            raise PublishError("at least one generated-data path is required")
+        for path in self.paths:
+            _validate_path_spec(path)
+        for path in self.required_tracked_paths:
+            _validate_path_spec(path)
+            if path.endswith("/"):
+                raise PublishError("required tracked paths must identify exact files")
+            if not any(_path_matches_spec(path, spec) for spec in self.paths):
+                raise PublishError(
+                    f"required tracked path is outside the generated-data allowlist: {path}"
+                )
+
+    @property
+    def owner(self) -> str:
+        return self.repository.split("/", maxsplit=1)[0]
+
+    @property
+    def ownership_marker(self) -> str:
+        return (
+            "<!-- dashboard-generated-data:"
+            f"{self.producer}:{self.base_branch}:{_MARKER_VERSION} -->"
+        )
+
+    @property
+    def repository_url(self) -> str:
+        return f"{self.server_url}/{self.repository}"
+
+
+@dataclass(frozen=True)
+class PublishResult:
+    status: str
+    pr_url: str = ""
+    head_sha: str = ""
+
+
+class GitHub(Protocol):
+    def setup_git_auth(self) -> None: ...
+
+    def list_open_pull_requests(self, config: Config) -> list[dict[str, Any]]: ...
+
+    def create_pull_request(
+        self,
+        config: Config,
+        *,
+        body: str,
+        head_sha: str,
+    ) -> dict[str, Any]: ...
+
+    def update_pull_request(
+        self,
+        config: Config,
+        pull_request: Mapping[str, Any],
+        *,
+        body: str,
+        head_sha: str,
+    ) -> dict[str, Any]: ...
+
+    def close_pull_request(
+        self,
+        config: Config,
+        pull_request: Mapping[str, Any],
+    ) -> dict[str, Any]: ...
+
+
+class Git:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def run(
+        self,
+        *arguments: str,
+        input_text: str | None = None,
+        check: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        try:
+            completed = subprocess.run(
+                ["git", "-C", str(self.root), *arguments],
+                input=input_text,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise PublishError(f"Git command failed: {exc}") from exc
+        if check and completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip()
+            raise PublishError(detail or f"Git command failed: {' '.join(arguments)}")
+        return completed
+
+    def text(self, *arguments: str) -> str:
+        return self.run(*arguments).stdout.strip()
+
+
+class GhClient:
+    def setup_git_auth(self) -> None:
+        self._run("auth", "setup-git")
+
+    def list_open_pull_requests(self, config: Config) -> list[dict[str, Any]]:
+        pull_requests: list[dict[str, Any]] = []
+        for page in range(1, 11):
+            query = urlencode(
+                {
+                    "state": "open",
+                    "head": f"{config.owner}:{config.head_branch}",
+                    "per_page": "100",
+                    "page": str(page),
+                }
+            )
+            payload = self._api("GET", f"repos/{config.repository}/pulls?{query}")
+            if not isinstance(payload, list) or not all(
+                isinstance(item, dict) for item in payload
+            ):
+                raise PublishError("GitHub returned a malformed pull-request collection")
+            pull_requests.extend(payload)
+            if len(payload) < 100:
+                return pull_requests
+        raise PublishError(
+            "too many open pull requests use the deterministic generated-data head"
+        )
+
+    def create_pull_request(
+        self,
+        config: Config,
+        *,
+        body: str,
+        head_sha: str,
+    ) -> dict[str, Any]:
+        del head_sha
+        payload = self._api(
+            "POST",
+            f"repos/{config.repository}/pulls",
+            {
+                "title": config.title,
+                "head": config.head_branch,
+                "base": config.base_branch,
+                "body": body,
+                "draft": True,
+                "maintainer_can_modify": False,
+            },
+        )
+        if not isinstance(payload, dict):
+            raise PublishError("GitHub returned a malformed created pull request")
+        return payload
+
+    def update_pull_request(
+        self,
+        config: Config,
+        pull_request: Mapping[str, Any],
+        *,
+        body: str,
+        head_sha: str,
+    ) -> dict[str, Any]:
+        del head_sha
+        number = _pull_request_number(pull_request)
+        payload = self._api(
+            "PATCH",
+            f"repos/{config.repository}/pulls/{number}",
+            {
+                "title": config.title,
+                "body": body,
+            },
+        )
+        if not isinstance(payload, dict):
+            raise PublishError("GitHub returned a malformed updated pull request")
+        return payload
+
+    def close_pull_request(
+        self,
+        config: Config,
+        pull_request: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        number = _pull_request_number(pull_request)
+        payload = self._api(
+            "PATCH",
+            f"repos/{config.repository}/pulls/{number}",
+            {"state": "closed"},
+        )
+        if not isinstance(payload, dict):
+            raise PublishError("GitHub returned a malformed closed pull request")
+        return payload
+
+    def _api(
+        self,
+        method: str,
+        endpoint: str,
+        payload: Mapping[str, object] | None = None,
+    ) -> object:
+        arguments = ["api", "--method", method, endpoint]
+        input_text = None
+        if payload is not None:
+            arguments.extend(["--input", "-"])
+            input_text = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+        completed = self._run(*arguments, input_text=input_text)
+        try:
+            return json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise PublishError("GitHub CLI returned non-JSON API output") from exc
+
+    def _run(
+        self,
+        *arguments: str,
+        input_text: str | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        try:
+            completed = subprocess.run(
+                ["gh", *arguments],
+                input=input_text,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=120,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise PublishError(f"GitHub CLI command failed: {exc}") from exc
+        if completed.returncode != 0:
+            detail = (completed.stderr or completed.stdout).strip()
+            raise PublishError(detail or "GitHub CLI command failed")
+        return completed
+
+
+def publish_generated_data(
+    config: Config,
+    *,
+    repository_root: Path,
+    github: GitHub,
+) -> PublishResult:
+    """Publish one exact generated-data state without writing the base branch."""
+
+    config.validate()
+    root = repository_root.expanduser().resolve(strict=True)
+    if not root.is_dir() or root.is_symlink():
+        raise PublishError("repository root must be a real directory")
+    git = Git(root)
+    top_level = Path(git.text("rev-parse", "--show-toplevel")).resolve(strict=True)
+    if top_level != root:
+        raise PublishError("publisher must run at the Git worktree root")
+    for branch in (config.base_branch, config.head_branch):
+        git.run("check-ref-format", "--branch", branch)
+    origin_url = git.text("config", "--get", "remote.origin.url").removesuffix("/")
+    if origin_url.removesuffix(".git") != config.repository_url:
+        raise PublishError("Git origin does not match GITHUB_REPOSITORY")
+
+    current_sha = git.text("rev-parse", "--verify", "HEAD^{commit}")
+    if current_sha != config.expected_base_sha:
+        raise PublishError("worktree HEAD does not match the reviewed generated-data base")
+    if git.run("diff", "--cached", "--quiet", check=False).returncode != 0:
+        raise PublishError("publisher requires an initially empty Git index")
+
+    _verify_required_tracked_paths(git, root, config.required_tracked_paths)
+    tracked_dirty, untracked = _worktree_candidate_paths(git)
+    _verify_candidate_worktree(
+        git,
+        root,
+        tracked_dirty=tracked_dirty,
+        untracked=untracked,
+        path_specs=config.paths,
+        required_tracked_paths=config.required_tracked_paths,
+    )
+
+    _assert_remote_base_unchanged(git, config)
+
+    open_pr = _one_owned_open_pull_request(config, github.list_open_pull_requests(config))
+    remote_sha = _remote_head_sha(git, config.head_branch)
+    if open_pr is not None and remote_sha is None:
+        raise PublishError("automation-owned pull request has no matching remote head branch")
+    if (
+        open_pr is not None
+        and _pull_request_head_sha(open_pr) != remote_sha
+    ):
+        raise PublishError("automation-owned pull request head does not match its remote branch")
+    remote_trailers: dict[str, str] = {}
+    if remote_sha is not None:
+        remote_trailers = _verify_remote_branch_ownership(git, config, remote_sha)
+
+    git.run("add", "-A", "--", *config.paths)
+    changed_paths = _staged_paths(git)
+    _verify_changed_paths(root, changed_paths, config.paths)
+    _verify_index_modes(git, changed_paths)
+    _verify_required_tracked_paths(git, root, config.required_tracked_paths)
+    remaining_dirty, remaining_untracked = _worktree_candidate_paths(git)
+    if remaining_dirty or remaining_untracked:
+        raise PublishError(
+            "generated-data candidate changed while the reviewed index was prepared"
+        )
+
+    if not changed_paths:
+        _assert_remote_base_unchanged(git, config)
+        open_pr = _require_same_open_pull_request_snapshot(
+            config,
+            expected=open_pr,
+            observed=github.list_open_pull_requests(config),
+        )
+        if open_pr is None:
+            return PublishResult(status="no_changes")
+        closed = github.close_pull_request(config, open_pr)
+        _validate_pull_request_ownership(config, closed, expected_state="closed")
+        if _pull_request_ownership_snapshot(closed) != _pull_request_ownership_snapshot(
+            open_pr
+        ):
+            raise PublishError(
+                "GitHub closed a generated-data pull request with a changed ownership snapshot"
+            )
+        _wait_for_no_open_pull_request(config, github)
+        _assert_remote_base_unchanged(git, config)
+        return PublishResult(status="closed_stale")
+
+    candidate_tree = git.text("write-tree")
+    head_sha = ""
+    pushed = False
+    if remote_sha is not None:
+        remote_tree = git.text("rev-parse", f"{remote_sha}^{{tree}}")
+        if (
+            remote_tree == candidate_tree
+            and remote_trailers.get(_TRAILER_BASE_SHA) == config.expected_base_sha
+            and remote_trailers.get(_TRAILER_BASE_BRANCH) == config.base_branch
+        ):
+            head_sha = remote_sha
+
+    if not head_sha:
+        open_pr = _require_same_open_pull_request_snapshot(
+            config,
+            expected=open_pr,
+            observed=github.list_open_pull_requests(config),
+        )
+        git.run("switch", "--create", config.head_branch)
+        git.run("config", "user.name", "github-actions[bot]")
+        git.run(
+            "config",
+            "user.email",
+            "41898282+github-actions[bot]@users.noreply.github.com",
+        )
+        commit_body = _commit_body(config)
+        git.run("commit", "--no-gpg-sign", "--file", "-", input_text=commit_body)
+        head_sha = git.text("rev-parse", "--verify", "HEAD^{commit}")
+        github.setup_git_auth()
+        expected_remote = remote_sha or ""
+        git.run(
+            "push",
+            f"--force-with-lease=refs/heads/{config.head_branch}:{expected_remote}",
+            "origin",
+            f"HEAD:refs/heads/{config.head_branch}",
+        )
+        published_sha = _remote_head_sha(git, config.head_branch)
+        if published_sha != head_sha:
+            raise PublishError("remote generated-data branch does not match the published commit")
+        pushed = True
+
+    _assert_remote_base_unchanged(git, config)
+    open_pr = _require_same_open_pull_request_snapshot(
+        config,
+        expected=open_pr,
+        observed=github.list_open_pull_requests(config),
+    )
+    body = _pull_request_body(config, head_sha=head_sha, changed_paths=changed_paths)
+    if open_pr is None:
+        try:
+            pull_request = github.create_pull_request(
+                config,
+                body=body,
+                head_sha=head_sha,
+            )
+        except PublishError:
+            pull_request = _recover_created_pull_request(config, github, head_sha)
+        status = "created"
+    else:
+        pull_request = github.update_pull_request(
+            config,
+            open_pr,
+            body=body,
+            head_sha=head_sha,
+        )
+        status = "updated" if pushed else "unchanged"
+
+    verified = _wait_for_exact_pull_request(
+        config,
+        github,
+        expected_number=_pull_request_number(pull_request),
+        expected_head_sha=head_sha,
+        expected_body=body,
+    )
+    _assert_remote_base_unchanged(git, config)
+    return PublishResult(
+        status=status,
+        pr_url=str(verified["html_url"]),
+        head_sha=head_sha,
+    )
+
+
+def _parse_path_list(raw: str) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                line.strip()
+                for line in raw.splitlines()
+                if line.strip()
+            }
+        )
+    )
+
+
+def _validate_branch(value: str, label: str) -> None:
+    if not _BRANCH_RE.fullmatch(value) or "//" in value or value.endswith(("/", ".")):
+        raise PublishError(f"{label} is not a bounded canonical branch name")
+
+
+def _validate_single_line(value: str, label: str, *, maximum: int) -> None:
+    if (
+        not value
+        or value != value.strip()
+        or len(value) > maximum
+        or any(character in value for character in "\x00\r\n")
+    ):
+        raise PublishError(f"{label} must be one bounded trimmed line")
+
+
+def _validate_pr_credentials(author_login: str, credential_source: str) -> None:
+    if (
+        not isinstance(author_login, str)
+        or not _PR_AUTHOR_LOGIN_RE.fullmatch(author_login)
+        or len(author_login) > 105
+    ):
+        raise PublishError("expected PR author login is malformed")
+    if (
+        not isinstance(credential_source, str)
+        or credential_source not in _CREDENTIAL_SOURCES
+    ):
+        raise PublishError(
+            "credential source must be 'github-token' or 'github-app'"
+        )
+    normalized_author = author_login.casefold()
+    if (
+        credential_source == _CREDENTIAL_SOURCE_GITHUB_TOKEN
+        and normalized_author != _DEFAULT_PR_AUTHOR_LOGIN
+    ):
+        raise PublishError(
+            "github-token credential source requires github-actions[bot] as the "
+            "expected PR author"
+        )
+    if credential_source == _CREDENTIAL_SOURCE_GITHUB_APP:
+        if not normalized_author.endswith("[bot]"):
+            raise PublishError(
+                "github-app credential source requires a GitHub App bot author"
+            )
+        if normalized_author == _DEFAULT_PR_AUTHOR_LOGIN:
+            raise PublishError(
+                "github-app credential source requires the installed App bot author"
+            )
+
+
+def _validate_path_spec(value: str) -> None:
+    raw = value.removesuffix("/")
+    path = PurePosixPath(raw)
+    if (
+        not raw
+        or "\\" in value
+        or any(ord(character) < 32 or ord(character) == 127 for character in value)
+        or path.is_absolute()
+        or path.as_posix() != raw
+        or any(part in {"", ".", ".."} for part in path.parts)
+    ):
+        raise PublishError(f"generated-data path is unsafe: {value!r}")
+
+
+def _staged_paths(git: Git) -> tuple[str, ...]:
+    output = git.run(
+        "diff",
+        "--cached",
+        "--name-only",
+        "--diff-filter=ACDMRTUXB",
+        "-z",
+    ).stdout
+    paths = tuple(sorted(item for item in output.split("\x00") if item))
+    if len(paths) != len(set(paths)):
+        raise PublishError("Git returned duplicate staged paths")
+    return paths
+
+
+def _verify_changed_paths(
+    root: Path,
+    changed_paths: Sequence[str],
+    path_specs: Sequence[str],
+) -> None:
+    _verify_paths_allowlisted(changed_paths, path_specs)
+    for value in changed_paths:
+        _verify_regular_path_boundary(root, value, require_file=False)
+
+
+def _verify_paths_allowlisted(
+    changed_paths: Sequence[str],
+    path_specs: Sequence[str],
+) -> None:
+    for value in changed_paths:
+        _validate_path_spec(value)
+        if not any(_path_matches_spec(value, spec) for spec in path_specs):
+            raise PublishError(f"changed path is outside the generated-data allowlist: {value}")
+
+
+def _path_matches_spec(path: str, spec: str) -> bool:
+    if spec.endswith("/"):
+        return path.startswith(spec) and len(path) > len(spec)
+    return path == spec
+
+
+def _worktree_candidate_paths(git: Git) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    tracked_dirty = _nul_paths(
+        git.run(
+            "diff",
+            "--name-only",
+            "--no-renames",
+            "--diff-filter=ACDMRTUXB",
+            "-z",
+            "--",
+        ).stdout,
+        description="dirty tracked",
+    )
+    untracked = _nul_paths(
+        git.run(
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+            "-z",
+            "--",
+        ).stdout,
+        description="untracked",
+    )
+    return tracked_dirty, untracked
+
+
+def _nul_paths(output: str, *, description: str) -> tuple[str, ...]:
+    paths = tuple(sorted(item for item in output.split("\x00") if item))
+    if len(paths) != len(set(paths)):
+        raise PublishError(f"Git returned duplicate {description} paths")
+    for path in paths:
+        _validate_path_spec(path)
+    return paths
+
+
+def _verify_candidate_worktree(
+    git: Git,
+    root: Path,
+    *,
+    tracked_dirty: Sequence[str],
+    untracked: Sequence[str],
+    path_specs: Sequence[str],
+    required_tracked_paths: Sequence[str],
+) -> None:
+    _verify_paths_allowlisted(tracked_dirty, path_specs)
+    _verify_paths_allowlisted(untracked, path_specs)
+    required = set(required_tracked_paths)
+    unexpected_untracked = sorted(required.intersection(untracked))
+    if unexpected_untracked:
+        raise PublishError(
+            "required generated-data files became untracked: "
+            f"{unexpected_untracked[:3]!r}"
+        )
+    _verify_index_modes(git, tracked_dirty)
+    for path in (*tracked_dirty, *untracked):
+        _verify_regular_path_boundary(root, path, require_file=False)
+
+
+def _verify_required_tracked_paths(
+    git: Git,
+    root: Path,
+    required_paths: Sequence[str],
+) -> None:
+    for path in required_paths:
+        entries = _index_entries(git, path)
+        if len(entries) != 1:
+            raise PublishError(
+                f"required generated-data file is not tracked exactly once: {path}"
+            )
+        mode, stage, indexed_path = entries[0]
+        if indexed_path != path or stage != "0" or mode not in {"100644", "100755"}:
+            raise PublishError(
+                f"required generated-data file is not a tracked regular file: {path}"
+            )
+        _verify_regular_path_boundary(root, path, require_file=True)
+
+
+def _verify_index_modes(git: Git, paths: Sequence[str]) -> None:
+    for path in paths:
+        for mode, stage, indexed_path in _index_entries(git, path):
+            if indexed_path != path or stage != "0":
+                raise PublishError(f"generated-data index entry is conflicted: {path}")
+            if mode not in {"100644", "100755"}:
+                raise PublishError(
+                    f"generated-data output must be a regular file: {path}"
+                )
+
+
+def _index_entries(git: Git, path: str) -> tuple[tuple[str, str, str], ...]:
+    output = git.run("ls-files", "--stage", "-z", "--", path).stdout
+    entries: list[tuple[str, str, str]] = []
+    for record in (item for item in output.split("\x00") if item):
+        metadata, separator, indexed_path = record.partition("\t")
+        fields = metadata.split()
+        if not separator or len(fields) != 3:
+            raise PublishError("Git returned a malformed index entry")
+        mode, object_id, stage = fields
+        if not re.fullmatch(r"[0-9a-f]{40,64}", object_id):
+            raise PublishError("Git returned a malformed index object")
+        entries.append((mode, stage, indexed_path))
+    return tuple(entries)
+
+
+def _verify_regular_path_boundary(
+    root: Path,
+    value: str,
+    *,
+    require_file: bool,
+) -> None:
+    _validate_path_spec(value)
+    candidate = root
+    parts = PurePosixPath(value).parts
+    for index, part in enumerate(parts):
+        candidate /= part
+        try:
+            metadata = candidate.lstat()
+        except FileNotFoundError:
+            if require_file:
+                raise PublishError(
+                    f"required generated-data file is missing: {value}"
+                )
+            return
+        except OSError as exc:
+            raise PublishError(f"generated-data path could not be inspected: {value}") from exc
+        if stat.S_ISLNK(metadata.st_mode):
+            raise PublishError(f"generated-data path must not use symlinks: {value}")
+        if index < len(parts) - 1:
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise PublishError(
+                    f"generated-data parent must be a directory: {value}"
+                )
+        elif not stat.S_ISREG(metadata.st_mode):
+            raise PublishError(f"generated-data output must be a regular file: {value}")
+
+
+def _remote_head_sha(git: Git, branch: str) -> str | None:
+    output = git.text("ls-remote", "--heads", "origin", f"refs/heads/{branch}")
+    if not output:
+        return None
+    lines = output.splitlines()
+    if len(lines) != 1:
+        raise PublishError("remote returned multiple generated-data branch heads")
+    fields = lines[0].split()
+    if len(fields) != 2 or fields[1] != f"refs/heads/{branch}" or not _SHA_RE.fullmatch(fields[0]):
+        raise PublishError("remote returned a malformed generated-data branch head")
+    return fields[0]
+
+
+def _assert_remote_base_unchanged(git: Git, config: Config) -> None:
+    git.run(
+        "fetch",
+        "--no-tags",
+        "origin",
+        f"+refs/heads/{config.base_branch}:refs/remotes/origin/{config.base_branch}",
+    )
+    remote_base_sha = git.text(
+        "rev-parse",
+        "--verify",
+        f"refs/remotes/origin/{config.base_branch}^{{commit}}",
+    )
+    if remote_base_sha != config.expected_base_sha:
+        raise PublishError(
+            "base branch changed after generation; rerun against the new base instead of "
+            "publishing stale data"
+        )
+
+
+def _verify_remote_branch_ownership(
+    git: Git,
+    config: Config,
+    remote_sha: str,
+) -> dict[str, str]:
+    git.run("fetch", "--no-tags", "origin", f"refs/heads/{config.head_branch}")
+    fetched_sha = git.text("rev-parse", "--verify", "FETCH_HEAD^{commit}")
+    if fetched_sha != remote_sha:
+        raise PublishError("generated-data branch changed while ownership was verified")
+    message = git.run("show", "-s", "--format=%B", remote_sha).stdout
+    trailers = _parse_trailers(message)
+    expected = {
+        _TRAILER_PRODUCER: config.producer,
+        _TRAILER_BRANCH: config.head_branch,
+        _TRAILER_BASE_BRANCH: config.base_branch,
+    }
+    if any(trailers.get(key) != value for key, value in expected.items()):
+        raise PublishError(
+            "refusing to replace a generated-data branch without exact automation ownership"
+        )
+    recorded_base_sha = trailers.get(_TRAILER_BASE_SHA, "")
+    if not _SHA_RE.fullmatch(recorded_base_sha):
+        raise PublishError("automation-owned branch has an invalid recorded base SHA")
+    parents = git.text("show", "-s", "--format=%P", remote_sha).split()
+    if parents != [recorded_base_sha]:
+        raise PublishError(
+            "automation-owned branch is not one generated commit on its recorded base"
+        )
+    remote_paths = _changed_paths_between(git, recorded_base_sha, remote_sha)
+    _verify_paths_allowlisted(remote_paths, config.paths)
+    return trailers
+
+
+def _parse_trailers(message: str) -> dict[str, str]:
+    trailers: dict[str, str] = {}
+    for line in message.splitlines():
+        key, separator, value = line.partition(":")
+        if not separator or key not in {
+            _TRAILER_PRODUCER,
+            _TRAILER_BRANCH,
+            _TRAILER_BASE_BRANCH,
+            _TRAILER_BASE_SHA,
+        }:
+            continue
+        cleaned = value.strip()
+        if key in trailers:
+            raise PublishError(f"automation commit contains duplicate trailer {key}")
+        trailers[key] = cleaned
+    return trailers
+
+
+def _changed_paths_between(git: Git, base_sha: str, head_sha: str) -> tuple[str, ...]:
+    output = git.run(
+        "diff",
+        "--name-only",
+        "--diff-filter=ACDMRTUXB",
+        "-z",
+        base_sha,
+        head_sha,
+        "--",
+    ).stdout
+    paths = tuple(sorted(item for item in output.split("\x00") if item))
+    if len(paths) != len(set(paths)):
+        raise PublishError("Git returned duplicate changed paths")
+    return paths
+
+
+def _commit_body(config: Config) -> str:
+    return (
+        f"{config.commit_message}\n\n"
+        f"{_TRAILER_PRODUCER}: {config.producer}\n"
+        f"{_TRAILER_BRANCH}: {config.head_branch}\n"
+        f"{_TRAILER_BASE_BRANCH}: {config.base_branch}\n"
+        f"{_TRAILER_BASE_SHA}: {config.expected_base_sha}\n"
+    )
+
+
+def _pull_request_body(
+    config: Config,
+    *,
+    head_sha: str,
+    changed_paths: Sequence[str],
+) -> str:
+    rendered_paths = "\n".join(f"- `{path}`" for path in changed_paths)
+    if config.credential_source == _CREDENTIAL_SOURCE_GITHUB_TOKEN:
+        credential_label = "GitHub Actions built-in `GITHUB_TOKEN`"
+        credential_guidance = (
+            "This pull request is created with the repository's built-in "
+            "`GITHUB_TOKEN`. GitHub may suppress recursive workflow starts or place "
+            "workflow runs behind repository approval. An authorized reviewer must "
+            "verify that every required check actually ran before merge."
+        )
+    else:
+        credential_label = "short-lived GitHub App installation token"
+        credential_guidance = (
+            "This pull request is created with a short-lived GitHub App installation "
+            "token. App-authored pull-request events can trigger repository checks, "
+            "subject to repository policy. Required checks and independent review "
+            "remain mandatory before merge."
+        )
+    return (
+        f"{config.ownership_marker}\n"
+        "# Generated data review\n\n"
+        "This draft contains deterministic generated-data updates. It does not merge "
+        "or write the base branch directly.\n\n"
+        f"- Producer: `{config.producer}`\n"
+        f"- Reviewed base: `{config.base_branch}` at `{config.expected_base_sha}`\n"
+        f"- Candidate commit: `{head_sha}`\n"
+        f"- Source run: {config.run_url}\n"
+        f"- Pull-request credential: {credential_label}\n"
+        f"- Expected PR author: `{config.expected_pr_author_login}`\n\n"
+        "Changed files:\n"
+        f"{rendered_paths}\n\n"
+        "This source run will not deploy while generated changes require review. After "
+        "this draft is reviewed and merged, a clean rerun against the merged base may "
+        "deploy.\n\n"
+        "## External production activation blockers\n\n"
+        "Repository owners must configure live required approving reviews and required "
+        "checks, enforce those rules for administrators, and configure a protected "
+        "production environment. The deployment workflow must not be merged or activated "
+        "until owners have explicitly created and protected that environment.\n\n"
+        "## Credential behavior\n\n"
+        f"{credential_guidance} The publisher validates that the pull request is owned "
+        "by the configured author. It does not mint credentials, change repository "
+        "rules, approve workflows, merge pull requests, or configure an environment.\n\n"
+        "Review the generated diff and all required checks before marking this PR ready.\n"
+    )
+
+
+def _one_owned_open_pull_request(
+    config: Config,
+    pull_requests: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    for pull_request in pull_requests:
+        _validate_pull_request_ownership(
+            config,
+            pull_request,
+            expected_state="open",
+        )
+    if len(pull_requests) > 1:
+        raise PublishError("multiple open PRs use the deterministic generated-data branch")
+    if not pull_requests:
+        return None
+    return pull_requests[0]
+
+
+def _validate_pull_request_ownership(
+    config: Config,
+    pull_request: Mapping[str, Any],
+    *,
+    expected_state: str,
+) -> None:
+    state = str(pull_request.get("state", "")).casefold()
+    if state != expected_state:
+        raise PublishError(
+            "deterministic generated-data PR has an unexpected lifecycle state"
+        )
+    head = pull_request.get("head")
+    base = pull_request.get("base")
+    head_repo = head.get("repo") if isinstance(head, Mapping) else None
+    base_repo = base.get("repo") if isinstance(base, Mapping) else None
+    if (
+        not isinstance(head, Mapping)
+        or head.get("ref") != config.head_branch
+        or not isinstance(head_repo, Mapping)
+        or str(head_repo.get("full_name", "")).casefold()
+        != config.repository.casefold()
+    ):
+        raise PublishError(
+            "deterministic generated-data PR has an unexpected head branch or repository"
+        )
+    if (
+        not isinstance(base, Mapping)
+        or base.get("ref") != config.base_branch
+        or not isinstance(base_repo, Mapping)
+        or str(base_repo.get("full_name", "")).casefold()
+        != config.repository.casefold()
+    ):
+        raise PublishError(
+            "deterministic generated-data PR was retargeted to an unexpected base"
+        )
+    body = pull_request.get("body")
+    if not isinstance(body, str) or config.ownership_marker not in body:
+        raise PublishError("deterministic generated-data PR is not automation-owned")
+    user = pull_request.get("user")
+    author_login = user.get("login") if isinstance(user, Mapping) else None
+    if (
+        not isinstance(author_login, str)
+        or author_login.casefold() != config.expected_pr_author_login.casefold()
+    ):
+        raise PublishError("deterministic generated-data PR has the wrong author")
+    if pull_request.get("draft") is not True:
+        raise PublishError(
+            "refusing to rewrite a generated-data PR after it leaves draft review"
+        )
+    if _pull_request_base_sha(pull_request) != config.expected_base_sha:
+        raise PublishError("generated-data PR is not bound to the exact reviewed base SHA")
+    if not _SHA_RE.fullmatch(_pull_request_head_sha(pull_request)):
+        raise PublishError("generated-data PR has an invalid head SHA")
+    _pull_request_number(pull_request)
+
+
+def _require_same_open_pull_request_snapshot(
+    config: Config,
+    *,
+    expected: Mapping[str, Any] | None,
+    observed: Sequence[Mapping[str, Any]],
+) -> Mapping[str, Any] | None:
+    current = _one_owned_open_pull_request(config, observed)
+    if expected is None:
+        if current is not None:
+            raise PublishError(
+                "a generated-data pull request appeared during publication"
+            )
+        return None
+    if (
+        current is None
+        or _pull_request_ownership_snapshot(current)
+        != _pull_request_ownership_snapshot(expected)
+    ):
+        raise PublishError(
+            "generated-data pull-request ownership snapshot changed during publication"
+        )
+    return current
+
+
+def _wait_for_no_open_pull_request(config: Config, github: GitHub) -> None:
+    for attempt in range(5):
+        current = _one_owned_open_pull_request(
+            config,
+            github.list_open_pull_requests(config),
+        )
+        if current is None:
+            return
+        if attempt < 4:
+            time.sleep(attempt + 1)
+    raise PublishError(
+        "obsolete generated-data PR closure was not stable; deployment remains blocked"
+    )
+
+
+def _pull_request_number(pull_request: Mapping[str, Any]) -> int:
+    number = pull_request.get("number")
+    if isinstance(number, bool) or not isinstance(number, int) or number < 1:
+        raise PublishError("pull request has an invalid number")
+    return number
+
+
+def _pull_request_ownership_snapshot(
+    pull_request: Mapping[str, Any],
+) -> tuple[object, ...]:
+    head = pull_request.get("head")
+    base = pull_request.get("base")
+    user = pull_request.get("user")
+    if (
+        not isinstance(head, Mapping)
+        or not isinstance(base, Mapping)
+        or not isinstance(user, Mapping)
+    ):
+        raise PublishError("pull request has a malformed ownership snapshot")
+    head_repo = head.get("repo")
+    base_repo = base.get("repo")
+    if not isinstance(head_repo, Mapping) or not isinstance(base_repo, Mapping):
+        raise PublishError("pull request has a malformed repository snapshot")
+    return (
+        _pull_request_number(pull_request),
+        pull_request.get("title"),
+        pull_request.get("body"),
+        pull_request.get("draft"),
+        user.get("login"),
+        head.get("ref"),
+        head.get("sha"),
+        head_repo.get("full_name"),
+        base.get("ref"),
+        base.get("sha"),
+        base_repo.get("full_name"),
+    )
+
+
+def _recover_created_pull_request(
+    config: Config,
+    github: GitHub,
+    head_sha: str,
+) -> dict[str, Any]:
+    for attempt in range(5):
+        if attempt:
+            time.sleep(attempt)
+        pull_request = _one_owned_open_pull_request(
+            config,
+            github.list_open_pull_requests(config),
+        )
+        if pull_request is not None and _pull_request_head_sha(pull_request) == head_sha:
+            return dict(pull_request)
+    raise PublishError("pull-request creation failed without a recoverable exact PR")
+
+
+def _wait_for_exact_pull_request(
+    config: Config,
+    github: GitHub,
+    *,
+    expected_number: int,
+    expected_head_sha: str,
+    expected_body: str,
+) -> Mapping[str, Any]:
+    for attempt in range(5):
+        if attempt:
+            time.sleep(attempt)
+        pull_request = _one_owned_open_pull_request(
+            config,
+            github.list_open_pull_requests(config),
+        )
+        if (
+            pull_request is not None
+            and _pull_request_number(pull_request) == expected_number
+            and _pull_request_head_sha(pull_request) == expected_head_sha
+            and pull_request.get("title") == config.title
+            and pull_request.get("body") == expected_body
+            and pull_request.get("draft") is True
+            and _pull_request_base_sha(pull_request) == config.expected_base_sha
+            and isinstance(pull_request.get("html_url"), str)
+            and str(pull_request["html_url"]).startswith("https://")
+        ):
+            return pull_request
+    raise PublishError("GitHub did not expose the exact generated-data PR and branch head")
+
+
+def _pull_request_head_sha(pull_request: Mapping[str, Any]) -> str:
+    head = pull_request.get("head")
+    value = head.get("sha") if isinstance(head, Mapping) else None
+    return value if isinstance(value, str) else ""
+
+
+def _pull_request_base_sha(pull_request: Mapping[str, Any]) -> str:
+    base = pull_request.get("base")
+    value = base.get("sha") if isinstance(base, Mapping) else None
+    return value if isinstance(value, str) else ""
+
+
+def _write_outputs(path: Path | None, result: PublishResult) -> None:
+    lines = {
+        "status": result.status,
+        "pr_url": result.pr_url,
+        "head_sha": result.head_sha,
+    }
+    for key, value in lines.items():
+        if any(character in value for character in "\x00\r\n"):
+            raise PublishError(f"unsafe workflow output value for {key}")
+    if path is not None:
+        with path.open("a", encoding="utf-8") as output:
+            for key, value in lines.items():
+                output.write(f"{key}={value}\n")
+    print(f"generated-data status: {result.status}")
+    if result.pr_url:
+        print(f"generated-data review PR: {result.pr_url}")
+
+
+def main() -> int:
+    try:
+        config = Config.from_environment(os.environ)
+        workspace = os.environ.get("GITHUB_WORKSPACE", "").strip()
+        if not workspace:
+            raise PublishError("GITHUB_WORKSPACE is required")
+        result = publish_generated_data(
+            config,
+            repository_root=Path(workspace),
+            github=GhClient(),
+        )
+        _write_outputs(config.output_path, result)
+        return 0
+    except (OSError, PublishError) as exc:
+        print(f"generated-data publication failed safely: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/publish-generated-data-pr/tests/test_generated_data_pr.py
+++ b/.github/actions/publish-generated-data-pr/tests/test_generated_data_pr.py
@@ -1,0 +1,1037 @@
+from __future__ import annotations
+
+import copy
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any, Callable, Mapping
+from unittest.mock import patch
+
+ACTION_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ACTION_ROOT))
+
+import generated_data_pr as publisher  # noqa: E402
+from generated_data_pr import (  # noqa: E402
+    Config,
+    GhClient,
+    PublishError,
+    publish_generated_data,
+)
+
+class FakeGitHub:
+    def __init__(self) -> None:
+        self.pull_requests: list[dict[str, Any]] = []
+        self.auth_calls = 0
+        self.list_calls = 0
+        self.on_setup_git_auth: Callable[[], None] | None = None
+        self.on_close: Callable[[dict[str, Any]], None] | None = None
+        self.on_list: Callable[[int, list[dict[str, Any]]], None] | None = None
+
+    def setup_git_auth(self) -> None:
+        self.auth_calls += 1
+        if self.on_setup_git_auth is not None:
+            self.on_setup_git_auth()
+
+    def list_open_pull_requests(self, config: Config) -> list[dict[str, Any]]:
+        self.list_calls += 1
+        if self.on_list is not None:
+            self.on_list(self.list_calls, self.pull_requests)
+        return [
+            copy.deepcopy(pull_request)
+            for pull_request in self.pull_requests
+            if pull_request["state"] == "open"
+            and pull_request["head"]["ref"] == config.head_branch
+        ]
+
+    def create_pull_request(
+        self,
+        config: Config,
+        *,
+        body: str,
+        head_sha: str,
+    ) -> dict[str, Any]:
+        pull_request = self._payload(
+            config,
+            number=len(self.pull_requests) + 1,
+            body=body,
+            head_sha=head_sha,
+        )
+        self.pull_requests.append(pull_request)
+        return pull_request
+
+    def update_pull_request(
+        self,
+        config: Config,
+        pull_request: Mapping[str, Any],
+        *,
+        body: str,
+        head_sha: str,
+    ) -> dict[str, Any]:
+        stored = self.pull_requests[int(pull_request["number"]) - 1]
+        stored["title"] = config.title
+        stored["body"] = body
+        stored["head"]["sha"] = head_sha
+        return stored
+
+    def close_pull_request(
+        self,
+        config: Config,
+        pull_request: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        del config
+        stored = self.pull_requests[int(pull_request["number"]) - 1]
+        stored["state"] = "closed"
+        response = copy.deepcopy(stored)
+        if self.on_close is not None:
+            self.on_close(stored)
+        return response
+
+    @staticmethod
+    def _payload(
+        config: Config,
+        *,
+        number: int,
+        body: str,
+        head_sha: str,
+    ) -> dict[str, Any]:
+        return {
+            "number": number,
+            "html_url": f"https://github.com/{config.repository}/pull/{number}",
+            "state": "open",
+            "draft": True,
+            "title": config.title,
+            "body": body,
+            "user": {"login": config.expected_pr_author_login},
+            "base": {
+                "ref": config.base_branch,
+                "sha": config.expected_base_sha,
+                "repo": {"full_name": config.repository},
+            },
+            "head": {
+                "ref": config.head_branch,
+                "sha": head_sha,
+                "repo": {"full_name": config.repository},
+            },
+        }
+
+
+class PublisherConfigurationTests(unittest.TestCase):
+    def test_environment_defaults_to_builtin_token_and_actions_bot(self) -> None:
+        config = Config.from_environment(_valid_environment())
+
+        self.assertEqual(config.credential_source, "github-token")
+        self.assertEqual(config.expected_pr_author_login, "github-actions[bot]")
+
+    def test_environment_accepts_github_app_installation_identity(self) -> None:
+        environment = _valid_environment()
+        environment.update(
+            {
+                "GENERATED_DATA_CREDENTIAL_SOURCE": "github-app",
+                "GENERATED_DATA_EXPECTED_PR_AUTHOR_LOGIN": (
+                    "arm-ecosystem-publisher[bot]"
+                ),
+            }
+        )
+
+        config = Config.from_environment(environment)
+
+        self.assertEqual(config.credential_source, "github-app")
+        self.assertEqual(
+            config.expected_pr_author_login,
+            "arm-ecosystem-publisher[bot]",
+        )
+
+    def test_rejects_malformed_expected_author_logins(self) -> None:
+        malformed = (
+            "",
+            " github-actions[bot]",
+            "github-actions[bot] ",
+            "-publisher[bot]",
+            "publisher-[bot]",
+            "publisher bot",
+            "owner/publisher[bot]",
+            "publisher[admin]",
+            f"{'a' * 101}[bot]",
+        )
+        for author_login in malformed:
+            with self.subTest(author_login=author_login):
+                environment = _valid_environment()
+                environment["GENERATED_DATA_EXPECTED_PR_AUTHOR_LOGIN"] = author_login
+                with self.assertRaisesRegex(PublishError, "author login is malformed"):
+                    Config.from_environment(environment)
+
+    def test_rejects_malformed_credential_sources(self) -> None:
+        for credential_source in (
+            "",
+            "github-token ",
+            "GITHUB-TOKEN",
+            "github_app",
+            "installation-token",
+            "personal-access-token",
+        ):
+            with self.subTest(credential_source=credential_source):
+                environment = _valid_environment()
+                environment["GENERATED_DATA_CREDENTIAL_SOURCE"] = credential_source
+                with self.assertRaisesRegex(PublishError, "credential source must be"):
+                    Config.from_environment(environment)
+
+    def test_rejects_author_and_credential_source_mismatches(self) -> None:
+        mismatches = (
+            ("github-token", "arm-ecosystem-publisher[bot]", "requires github-actions"),
+            ("github-app", "release-manager", "requires a GitHub App bot"),
+            ("github-app", "github-actions[bot]", "installed App bot author"),
+        )
+        for credential_source, author_login, error in mismatches:
+            with self.subTest(
+                credential_source=credential_source,
+                author_login=author_login,
+            ):
+                environment = _valid_environment()
+                environment.update(
+                    {
+                        "GENERATED_DATA_CREDENTIAL_SOURCE": credential_source,
+                        "GENERATED_DATA_EXPECTED_PR_AUTHOR_LOGIN": author_login,
+                    }
+                )
+                with self.assertRaisesRegex(PublishError, error):
+                    Config.from_environment(environment)
+
+
+class GeneratedDataPublisherTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.origin = self.root / "origin.git"
+        self.seed = self.root / "seed"
+        _git(self.root, "init", "--bare", str(self.origin))
+        _git(self.root, "init", "--initial-branch=main", str(self.seed))
+        _git(self.seed, "config", "user.name", "Test Author")
+        _git(self.seed, "config", "user.email", "test@example.com")
+        (self.seed / "data").mkdir()
+        (self.seed / "data/generated.yml").write_text("value: old\n", encoding="utf-8")
+        (self.seed / "unrelated.txt").write_text("base\n", encoding="utf-8")
+        _git(self.seed, "add", ".")
+        _git(self.seed, "commit", "-m", "Initial base")
+        _git(self.seed, "remote", "add", "origin", str(self.origin))
+        _git(self.seed, "push", "--set-upstream", "origin", "main")
+        self.base_sha = _git(self.seed, "rev-parse", "HEAD").stdout.strip()
+        self.github = FakeGitHub()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_reuses_one_branch_and_one_pr_across_reruns(self) -> None:
+        first = self._clone("first")
+        (first / "data/generated.yml").write_text("value: one\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+
+        second = self._clone("second")
+        (second / "data/generated.yml").write_text("value: one\n", encoding="utf-8")
+        unchanged = publish_generated_data(
+            self._config(),
+            repository_root=second,
+            github=self.github,
+        )
+
+        third = self._clone("third")
+        (third / "data/generated.yml").write_text("value: two\n", encoding="utf-8")
+        updated = publish_generated_data(
+            self._config(),
+            repository_root=third,
+            github=self.github,
+        )
+
+        self.assertEqual(created.status, "created")
+        self.assertEqual(unchanged.status, "unchanged")
+        self.assertEqual(updated.status, "updated")
+        self.assertEqual(len(self.github.pull_requests), 1)
+        self.assertNotEqual(created.head_sha, updated.head_sha)
+        self.assertEqual(self.github.pull_requests[0]["head"]["sha"], updated.head_sha)
+        self.assertEqual(self.github.auth_calls, 2)
+
+    def test_closes_only_owned_open_pr_when_diff_disappears(self) -> None:
+        first = self._clone("first-close")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+
+        clean = self._clone("clean")
+        result = publish_generated_data(
+            self._config(),
+            repository_root=clean,
+            github=self.github,
+        )
+
+        self.assertEqual(result.status, "closed_stale")
+        self.assertEqual(self.github.pull_requests[0]["state"], "closed")
+
+    def test_default_pr_body_describes_builtin_token_without_activation(self) -> None:
+        worktree = self._clone("approval-guidance")
+        (worktree / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        publish_generated_data(
+            self._config(),
+            repository_root=worktree,
+            github=self.github,
+        )
+
+        pull_request = self.github.pull_requests[0]
+        body = pull_request["body"]
+        self.assertEqual(pull_request["user"]["login"], "github-actions[bot]")
+        self.assertIn("will not deploy", body)
+        self.assertIn("clean rerun", body)
+        self.assertIn("`GITHUB_TOKEN`", body)
+        self.assertIn("required approving reviews", body)
+        self.assertIn("required checks", body)
+        self.assertIn("administrators", body)
+        self.assertIn("protected production", body)
+        self.assertIn("must not be merged or activated", body)
+        self.assertIn("GitHub Actions built-in `GITHUB_TOKEN`", body)
+        self.assertIn("Expected PR author: `github-actions[bot]`", body)
+        self.assertIn("may suppress recursive workflow starts", body)
+        self.assertIn("does not mint credentials, change repository rules", body)
+
+    def test_app_pr_body_describes_only_app_installation_credentials(self) -> None:
+        worktree = self._clone("app-credential-guidance")
+        (worktree / "data/generated.yml").write_text(
+            "value: proposed\n",
+            encoding="utf-8",
+        )
+        config = self._config(
+            credential_source="github-app",
+            expected_pr_author_login="arm-ecosystem-publisher[bot]",
+        )
+
+        publish_generated_data(
+            config,
+            repository_root=worktree,
+            github=self.github,
+        )
+
+        body = self.github.pull_requests[0]["body"]
+        self.assertIn("short-lived GitHub App installation token", body)
+        self.assertIn(
+            "Expected PR author: `arm-ecosystem-publisher[bot]`",
+            body,
+        )
+        self.assertIn("App-authored pull-request events", body)
+        self.assertNotIn("GITHUB_TOKEN", body)
+        self.assertNotIn("fine-grained PAT", body)
+
+    def test_app_author_ownership_comparison_is_case_insensitive(self) -> None:
+        config = self._config(
+            credential_source="github-app",
+            expected_pr_author_login="Arm-Ecosystem-Publisher[bot]",
+        )
+        first = self._clone("app-author-first")
+        (first / "data/generated.yml").write_text(
+            "value: proposed\n",
+            encoding="utf-8",
+        )
+        created = publish_generated_data(
+            config,
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["user"]["login"] = (
+            "arm-ecosystem-publisher[bot]"
+        )
+
+        second = self._clone("app-author-second")
+        (second / "data/generated.yml").write_text(
+            "value: proposed\n",
+            encoding="utf-8",
+        )
+        unchanged = publish_generated_data(
+            config,
+            repository_root=second,
+            github=self.github,
+        )
+
+        self.assertEqual(created.status, "created")
+        self.assertEqual(unchanged.status, "unchanged")
+
+    def test_refuses_to_overwrite_a_manual_remote_head(self) -> None:
+        first = self._clone("first-owned")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+
+        manual = self.root / "manual"
+        _git(
+            self.root,
+            "clone",
+            "--branch",
+            self._config().head_branch,
+            str(self.origin),
+            str(manual),
+        )
+        _git(manual, "config", "user.name", "Human")
+        _git(manual, "config", "user.email", "human@example.com")
+        (manual / "data/generated.yml").write_text("value: human\n", encoding="utf-8")
+        _git(manual, "add", "data/generated.yml")
+        _git(manual, "commit", "-m", "Human branch edit")
+        _git(manual, "push", "origin", self._config().head_branch)
+
+        next_run = self._clone("next-run")
+        (next_run / "data/generated.yml").write_text("value: next\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "head does not match its remote branch"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+    def test_force_with_lease_race_preserves_the_competing_remote_head(self) -> None:
+        worktree = self._clone("lease-race")
+        (worktree / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        raced_sha: list[str] = []
+
+        def create_competing_head() -> None:
+            racer = self.root / "lease-racer"
+            _git(
+                self.root,
+                "clone",
+                "--branch",
+                "main",
+                str(self.origin),
+                str(racer),
+            )
+            _git(racer, "config", "user.name", "Concurrent Writer")
+            _git(racer, "config", "user.email", "race@example.com")
+            _git(racer, "switch", "--create", self._config().head_branch)
+            (racer / "data/generated.yml").write_text("value: raced\n", encoding="utf-8")
+            _git(racer, "add", "data/generated.yml")
+            _git(racer, "commit", "-m", "Concurrent branch creation")
+            raced_sha.append(_git(racer, "rev-parse", "HEAD").stdout.strip())
+            _git(
+                racer,
+                "push",
+                "origin",
+                f"HEAD:refs/heads/{self._config().head_branch}",
+            )
+
+        self.github.on_setup_git_auth = create_competing_head
+
+        with self.assertRaises(PublishError):
+            publish_generated_data(
+                self._config(),
+                repository_root=worktree,
+                github=self.github,
+            )
+
+        self.assertEqual(self._remote_head_sha(), raced_sha[0])
+        self.assertEqual(self.github.pull_requests, [])
+
+    def test_stale_pr_closure_race_fails_closed(self) -> None:
+        first = self._clone("first-close-race")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.on_close = lambda pull_request: pull_request.update(state="open")
+
+        clean = self._clone("clean-close-race")
+        with patch.object(publisher.time, "sleep", return_value=None):
+            with self.assertRaisesRegex(PublishError, "closure was not stable"):
+                publish_generated_data(
+                    self._config(),
+                    repository_root=clean,
+                    github=self.github,
+                )
+
+        self.assertEqual(self.github.pull_requests[0]["state"], "open")
+        self.assertEqual(self._remote_head_sha(), created.head_sha)
+
+    def test_stale_pr_snapshot_change_blocks_closure(self) -> None:
+        first = self._clone("first-close-snapshot")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        mutation_call = self.github.list_calls + 2
+
+        def mutate_head_snapshot(
+            call_number: int,
+            pull_requests: list[dict[str, Any]],
+        ) -> None:
+            if call_number == mutation_call:
+                pull_requests[0]["head"]["sha"] = "e" * 40
+
+        self.github.on_list = mutate_head_snapshot
+        clean = self._clone("clean-close-snapshot")
+        with self.assertRaisesRegex(PublishError, "ownership snapshot changed"):
+            publish_generated_data(
+                self._config(),
+                repository_root=clean,
+                github=self.github,
+            )
+
+        self.assertEqual(self.github.pull_requests[0]["state"], "open")
+        self.assertEqual(self._remote_head_sha(), created.head_sha)
+
+    def test_stale_pr_body_edit_blocks_closure(self) -> None:
+        first = self._clone("first-close-body")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        mutation_call = self.github.list_calls + 2
+
+        def mutate_body_snapshot(
+            call_number: int,
+            pull_requests: list[dict[str, Any]],
+        ) -> None:
+            if call_number == mutation_call:
+                pull_requests[0]["body"] += "\nHuman review note.\n"
+
+        self.github.on_list = mutate_body_snapshot
+        clean = self._clone("clean-close-body")
+        with self.assertRaisesRegex(PublishError, "ownership snapshot changed"):
+            publish_generated_data(
+                self._config(),
+                repository_root=clean,
+                github=self.github,
+            )
+
+        self.assertEqual(self.github.pull_requests[0]["state"], "open")
+        self.assertEqual(self._remote_head_sha(), created.head_sha)
+
+    def test_refuses_to_rewrite_a_pr_that_has_left_draft_review(self) -> None:
+        first = self._clone("first-draft")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["draft"] = False
+
+        next_run = self._clone("next-draft")
+        (next_run / "data/generated.yml").write_text("value: changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "after it leaves draft review"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+        remote_sha = _git(
+            self.root,
+            "ls-remote",
+            str(self.origin),
+            f"refs/heads/{self._config().head_branch}",
+        ).stdout.split()[0]
+        self.assertEqual(remote_sha, created.head_sha)
+
+    def test_rejects_a_pr_not_bound_to_the_reviewed_base(self) -> None:
+        first = self._clone("first-pr-base")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["base"]["sha"] = "f" * 40
+
+        next_run = self._clone("next-pr-base")
+        (next_run / "data/generated.yml").write_text("value: changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "exact reviewed base SHA"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+    def test_retargeted_pr_blocks_branch_update(self) -> None:
+        first = self._clone("first-retarget")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["base"]["ref"] = "production"
+
+        next_run = self._clone("next-retarget")
+        (next_run / "data/generated.yml").write_text("value: changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "retargeted"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+        self.assertEqual(self._remote_head_sha(), created.head_sha)
+
+    def test_wrong_pr_repository_blocks_branch_update(self) -> None:
+        first = self._clone("first-wrong-pr-repo")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["head"]["repo"]["full_name"] = "example/fork"
+
+        next_run = self._clone("next-wrong-pr-repo")
+        (next_run / "data/generated.yml").write_text("value: changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "head branch or repository"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+        self.assertEqual(self._remote_head_sha(), created.head_sha)
+
+    def test_wrong_pr_base_repository_blocks_branch_update(self) -> None:
+        first = self._clone("first-wrong-pr-base-repo")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        created = publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["base"]["repo"]["full_name"] = "example/other"
+
+        next_run = self._clone("next-wrong-pr-base-repo")
+        (next_run / "data/generated.yml").write_text("value: changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "retargeted"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+        self.assertEqual(self._remote_head_sha(), created.head_sha)
+
+    def test_rejects_a_pr_with_the_wrong_author(self) -> None:
+        first = self._clone("first-pr-author")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["user"]["login"] = "human-reviewer"
+
+        next_run = self._clone("next-pr-author")
+        (next_run / "data/generated.yml").write_text("value: changed\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "wrong author"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+    def test_rejects_wrong_app_bot_actor(self) -> None:
+        config = self._config(
+            credential_source="github-app",
+            expected_pr_author_login="arm-ecosystem-publisher[bot]",
+        )
+        first = self._clone("first-app-pr-author")
+        (first / "data/generated.yml").write_text(
+            "value: proposed\n",
+            encoding="utf-8",
+        )
+        publish_generated_data(
+            config,
+            repository_root=first,
+            github=self.github,
+        )
+        self.github.pull_requests[0]["user"]["login"] = "other-app[bot]"
+
+        next_run = self._clone("next-app-pr-author")
+        (next_run / "data/generated.yml").write_text(
+            "value: changed\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(PublishError, "wrong author"):
+            publish_generated_data(
+                config,
+                repository_root=next_run,
+                github=self.github,
+            )
+
+    def test_rejects_forged_ownership_trailers_and_control_character_paths(self) -> None:
+        first = self._clone("first-forged")
+        (first / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        publish_generated_data(
+            self._config(),
+            repository_root=first,
+            github=self.github,
+        )
+
+        forged = self.root / "forged"
+        _git(
+            self.root,
+            "clone",
+            "--branch",
+            self._config().head_branch,
+            str(self.origin),
+            str(forged),
+        )
+        _git(forged, "config", "user.name", "Human")
+        _git(forged, "config", "user.email", "human@example.com")
+        (forged / "unrelated.txt").write_text("forged\n", encoding="utf-8")
+        _git(forged, "add", "unrelated.txt")
+        _git(
+            forged,
+            "commit",
+            "-m",
+            "Forged automation update",
+            "-m",
+            (
+                "Generated-Data-Producer: test-producer\n"
+                "Generated-Data-Branch: automation/generated-data/test-producer/main\n"
+                "Generated-Data-Base-Branch: main\n"
+                f"Generated-Data-Base-SHA: {self.base_sha}"
+            ),
+        )
+        _git(forged, "push", "origin", self._config().head_branch)
+        self.github.pull_requests[0]["state"] = "closed"
+
+        next_run = self._clone("next-forged")
+        (next_run / "data/generated.yml").write_text("value: next\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "not one generated commit"):
+            publish_generated_data(
+                self._config(),
+                repository_root=next_run,
+                github=self.github,
+            )
+
+        with self.assertRaisesRegex(PublishError, "unsafe"):
+            self._config(paths=("data/results/\n",))
+
+    def test_rejects_stale_base_and_preexisting_index_changes(self) -> None:
+        stale = self._clone("stale")
+        (self.seed / "unrelated.txt").write_text("new base\n", encoding="utf-8")
+        _git(self.seed, "add", "unrelated.txt")
+        _git(self.seed, "commit", "-m", "Advance base")
+        _git(self.seed, "push", "origin", "main")
+        (stale / "data/generated.yml").write_text("value: stale\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(PublishError, "base branch changed"):
+            publish_generated_data(
+                self._config(),
+                repository_root=stale,
+                github=self.github,
+            )
+
+        indexed = self._clone("indexed")
+        (indexed / "unrelated.txt").write_text("indexed\n", encoding="utf-8")
+        _git(indexed, "add", "unrelated.txt")
+        with self.assertRaisesRegex(PublishError, "initially empty Git index"):
+            publish_generated_data(
+                self._config(expected_base_sha=_git(indexed, "rev-parse", "HEAD").stdout.strip()),
+                repository_root=indexed,
+                github=self.github,
+            )
+
+    def test_rejects_unexpected_dirty_and_untracked_paths(self) -> None:
+        dirty = self._clone("unexpected-dirty")
+        (dirty / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        (dirty / "unrelated.txt").write_text("unexpected\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "outside the generated-data allowlist"):
+            publish_generated_data(
+                self._config(),
+                repository_root=dirty,
+                github=self.github,
+            )
+
+        untracked = self._clone("unexpected-untracked")
+        (untracked / "data/generated.yml").write_text("value: proposed\n", encoding="utf-8")
+        (untracked / "unexpected.txt").write_text("unexpected\n", encoding="utf-8")
+        with self.assertRaisesRegex(PublishError, "outside the generated-data allowlist"):
+            publish_generated_data(
+                self._config(),
+                repository_root=untracked,
+                github=self.github,
+            )
+
+        self.assertIsNone(self._remote_head_sha())
+
+    def test_allows_new_regular_files_only_inside_an_allowlisted_directory(self) -> None:
+        worktree = self._clone("allowlisted-new-file")
+        results = worktree / "data/results"
+        results.mkdir()
+        (results / "new.json").write_text('{"status":"passing"}\n', encoding="utf-8")
+
+        result = publish_generated_data(
+            self._config(
+                paths=("data/results/",),
+                required_tracked_paths=(),
+            ),
+            repository_root=worktree,
+            github=self.github,
+        )
+
+        self.assertEqual(result.status, "created")
+        changed = _git(
+            worktree,
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            result.head_sha,
+        ).stdout.splitlines()
+        self.assertEqual(changed, ["data/results/new.json"])
+
+    def test_required_generated_file_must_remain_tracked(self) -> None:
+        worktree = self._clone("required-untracked")
+        (worktree / "data/required.yml").write_text(
+            "value: untracked\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(PublishError, "not tracked exactly once"):
+            publish_generated_data(
+                self._config(
+                    paths=("data/required.yml",),
+                    required_tracked_paths=("data/required.yml",),
+                ),
+                repository_root=worktree,
+                github=self.github,
+            )
+
+        worktree = self._clone("required-deleted")
+        (worktree / "data/generated.yml").unlink()
+
+        with self.assertRaisesRegex(PublishError, "file is missing"):
+            publish_generated_data(
+                self._config(
+                    required_tracked_paths=("data/generated.yml",),
+                ),
+                repository_root=worktree,
+                github=self.github,
+            )
+
+    def test_rejects_symlink_output_and_unsafe_configuration(self) -> None:
+        worktree = self._clone("symlink")
+        generated = worktree / "data/generated.yml"
+        generated.unlink()
+        generated.symlink_to(worktree / "unrelated.txt")
+        with self.assertRaisesRegex(PublishError, "symlink|regular file"):
+            publish_generated_data(
+                self._config(),
+                repository_root=worktree,
+                github=self.github,
+            )
+
+        with self.assertRaisesRegex(PublishError, "producer namespace"):
+            self._config(head_branch="automation/generated-data/other/main")
+
+        wrong_origin = self._clone("wrong-origin")
+        _git(
+            wrong_origin,
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/example/other-repository.git",
+        )
+        with self.assertRaisesRegex(PublishError, "origin does not match"):
+            publish_generated_data(
+                self._config(),
+                repository_root=wrong_origin,
+                github=self.github,
+            )
+
+    def _clone(self, name: str) -> Path:
+        destination = self.root / name
+        _git(
+            self.root,
+            "clone",
+            "--branch",
+            "main",
+            str(self.origin),
+            str(destination),
+        )
+        canonical_origin = "https://github.com/example/dashboard.git"
+        _git(
+            destination,
+            "config",
+            f"url.{self.origin.resolve().as_uri()}.insteadOf",
+            canonical_origin,
+        )
+        _git(destination, "remote", "set-url", "origin", canonical_origin)
+        return destination
+
+    def _remote_head_sha(self) -> str | None:
+        completed = _git(
+            self.root,
+            "ls-remote",
+            str(self.origin),
+            f"refs/heads/{self._config().head_branch}",
+        )
+        output = completed.stdout.strip()
+        return output.split()[0] if output else None
+
+    def _config(self, **overrides: object) -> Config:
+        values: dict[str, object] = {
+            "producer": "test-producer",
+            "base_branch": "main",
+            "expected_base_sha": self.base_sha,
+            "head_branch": "automation/generated-data/test-producer/main",
+            "title": "Update generated test data",
+            "commit_message": "Update generated test data",
+            "paths": ("data/generated.yml",),
+            "required_tracked_paths": ("data/generated.yml",),
+            "repository": "example/dashboard",
+            "server_url": "https://github.com",
+            "run_url": "https://github.com/example/dashboard/actions/runs/1",
+            "output_path": None,
+        }
+        values.update(overrides)
+        config = Config(**values)  # type: ignore[arg-type]
+        config.validate()
+        return config
+
+
+class GitHubApiContractTests(unittest.TestCase):
+    def test_open_pr_discovery_is_paginated_and_independent_of_base(self) -> None:
+        first_page = [{"number": number} for number in range(1, 101)]
+        second_page = [{"number": 101}]
+        responses = [
+            subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=0,
+                stdout=publisher.json.dumps(first_page),
+                stderr="",
+            ),
+            subprocess.CompletedProcess(
+                args=["gh"],
+                returncode=0,
+                stdout=publisher.json.dumps(second_page),
+                stderr="",
+            ),
+        ]
+        config = Config(
+            producer="test-producer",
+            base_branch="main",
+            expected_base_sha="a" * 40,
+            head_branch="automation/generated-data/test-producer/main",
+            title="Update generated test data",
+            commit_message="Update generated test data",
+            paths=("data/generated.yml",),
+            required_tracked_paths=("data/generated.yml",),
+            repository="example/dashboard",
+            server_url="https://github.com",
+            run_url="https://github.com/example/dashboard/actions/runs/1",
+            output_path=None,
+        )
+
+        with patch.object(publisher.subprocess, "run", side_effect=responses) as run:
+            pull_requests = GhClient().list_open_pull_requests(config)
+
+        self.assertEqual(len(pull_requests), 101)
+        self.assertEqual(run.call_count, 2)
+        endpoints = [call.args[0][-1] for call in run.call_args_list]
+        self.assertTrue(all("head=example%3Aautomation%2Fgenerated-data" in item for item in endpoints))
+        self.assertTrue(all("base=" not in item for item in endpoints))
+        self.assertIn("page=1", endpoints[0])
+        self.assertIn("page=2", endpoints[1])
+
+
+class FoundationContractTests(unittest.TestCase):
+    def test_action_exposes_validated_credential_metadata_inputs(self) -> None:
+        action = (ACTION_ROOT / "action.yml").read_text(encoding="utf-8")
+
+        self.assertIn("expected-pr-author-login:", action)
+        self.assertIn("default: github-actions[bot]", action)
+        self.assertIn("credential-source:", action)
+        self.assertIn("default: github-token", action)
+        self.assertIn("GENERATED_DATA_EXPECTED_PR_AUTHOR_LOGIN:", action)
+        self.assertIn("GENERATED_DATA_CREDENTIAL_SOURCE:", action)
+
+    def test_foundation_ci_is_read_only_and_sha_pins_external_actions(self) -> None:
+        repository = ACTION_ROOT.parents[2]
+        workflow = (
+            repository
+            / ".github/workflows/generated-data-publisher-foundation-ci.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("permissions:\n  contents: read", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("pull-requests: write", workflow)
+        self.assertNotIn("secrets.", workflow)
+        self.assertIn("runs-on: ubuntu-24.04-arm", workflow)
+        self.assertIn("python3 -m unittest discover", workflow)
+        self.assertIn("actionlint_", workflow)
+        self.assertIn("_linux_arm64.tar.gz", workflow)
+        self.assertIn(
+            "325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6",
+            workflow,
+        )
+        self.assertIn("sha256sum --check --strict", workflow)
+        for line in workflow.splitlines():
+            if "uses:" not in line:
+                continue
+            reference = line.split("uses:", maxsplit=1)[1].strip()
+            _, separator, revision = reference.rpartition("@")
+            self.assertEqual(separator, "@")
+            self.assertRegex(revision, r"^[0-9a-f]{40}$")
+
+    def test_readme_declares_dormant_least_privilege_foundation(self) -> None:
+        readme = (ACTION_ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn("No existing", readme)
+        self.assertIn("production workflow invokes it", readme)
+        self.assertIn("does not change repository", readme)
+        self.assertIn("Generation and publication should be separate jobs", readme)
+        self.assertIn("contents: read", readme)
+        self.assertIn("short-lived credential", readme)
+        self.assertIn("does not activate", readme)
+
+
+def _valid_environment() -> dict[str, str]:
+    return {
+        "GENERATED_DATA_PRODUCER": "test-producer",
+        "GENERATED_DATA_BASE_BRANCH": "main",
+        "GENERATED_DATA_EXPECTED_BASE_SHA": "a" * 40,
+        "GENERATED_DATA_HEAD_BRANCH": (
+            "automation/generated-data/test-producer/main"
+        ),
+        "GENERATED_DATA_TITLE": "Update generated test data",
+        "GENERATED_DATA_COMMIT_MESSAGE": "Update generated test data",
+        "GENERATED_DATA_PATHS": "data/generated.yml",
+        "GENERATED_DATA_REQUIRED_TRACKED_PATHS": "data/generated.yml",
+        "GITHUB_REPOSITORY": "example/dashboard",
+        "GITHUB_SERVER_URL": "https://github.com",
+        "GITHUB_RUN_ID": "1",
+        "GITHUB_REF_NAME": "main",
+    }
+
+
+def _git(root: Path, *arguments: str) -> subprocess.CompletedProcess[str]:
+    completed = subprocess.run(
+        ["git", "-C", str(root), *arguments],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+    if completed.returncode != 0:
+        raise AssertionError(completed.stderr or completed.stdout)
+    return completed
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/generated-data-publisher-foundation-ci.yml
+++ b/.github/workflows/generated-data-publisher-foundation-ci.yml
@@ -1,0 +1,57 @@
+name: Generated data publisher foundation CI
+
+on:
+  pull_request:
+    paths:
+      - ".github/actions/publish-generated-data-pr/**"
+      - ".github/workflows/generated-data-publisher-foundation-ci.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  publisher-foundation:
+    name: Publisher foundation
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out candidate
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Run publisher unit tests
+        run: >-
+          python3 -m unittest discover
+          -s .github/actions/publish-generated-data-pr/tests
+          -p 'test_*.py'
+          -v
+
+      - name: Validate composite action YAML
+        run: >-
+          ruby -e
+          'require "yaml";
+          document = YAML.safe_load(
+            File.read(".github/actions/publish-generated-data-pr/action.yml"),
+            aliases: false
+          );
+          abort "action metadata must be a mapping" unless document.is_a?(Hash)'
+
+      - name: Lint foundation workflow
+        env:
+          ACTIONLINT_SHA256: 325e971b6ba9bfa504672e29be93c24981eeb1c07576d730e9f7c8805afff0c6
+          ACTIONLINT_VERSION: 1.7.12
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/actionlint.tar.gz"
+          binary="$RUNNER_TEMP/actionlint"
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --output "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_arm64.tar.gz"
+          printf '%s  %s\n' "$ACTIONLINT_SHA256" "$archive" | sha256sum --check --strict
+          tar --extract --gzip --file "$archive" --directory "$RUNNER_TEMP" actionlint
+          chmod 0755 "$binary"
+          "$binary" .github/workflows/generated-data-publisher-foundation-ci.yml


### PR DESCRIPTION
## Summary

Adds a dormant, reusable publisher primitive for deterministic generated-data draft pull requests. The publisher binds changes to an exact reviewed base SHA, limits commits to an explicit path allowlist, validates branch and PR ownership, uses force-with-lease, and supports either the built-in GitHub token or a scoped GitHub App installation token.

This PR does not invoke the action from any existing workflow, request write permissions, configure credentials or environments, alter repository rules, generate package content, deploy, or touch production data.

## Validation

- 32 publisher unit tests pass locally
- Actionlint 1.7.12 passes
- CI is read-only and runs on GitHub-hosted `ubuntu-24.04-arm`
- External checkout is SHA-pinned
- Actionlint is downloaded as the Arm64 release and SHA-256 verified
- No production workflow references this action

## Follow-up

Generation and publication will be integrated in later, separately reviewed PRs. Production activation remains disabled until repository governance and protected-environment controls are independently approved.