### PR TITLE
Limit all-batch orchestrator to schedule and manual runs

### DIFF
--- a/.github/workflows/test-all-packages-orchestrator.yml
+++ b/.github/workflows/test-all-packages-orchestrator.yml
@@ -14,14 +14,6 @@ on:
     # Weekly main-branch validation run: Friday night in US Central time.
     # 03:00 UTC Saturday is 10 PM CDT / 9 PM CST Friday.
     - cron: '0 3 * * 6'
-  push:
-    branches:
-      - main
-      - smoke_tests
-    paths:
-      - 'content/linux/opensource_packages/*.md'
-      - 'content/opensource_packages/*.md'
-      - '.github/workflows/*.yml'
 
 jobs:
   orchestrate-batches:

--- a/ARCHITECTURE_DIAGRAMS.md
+++ b/ARCHITECTURE_DIAGRAMS.md
@@ -9,7 +9,7 @@ This document is the high-level map for the Arm Ecosystem Dashboard smoke-test p
 ```text
 main branch
   |
-  | manual dispatch, workflow-path push, or weekly schedule
+  | manual dispatch or weekly schedule
   v
 .github/workflows/test-all-packages-orchestrator.yml
   |


### PR DESCRIPTION
## Summary
- Remove push-triggered fan-out from the all-package orchestrator.
- Keep weekly scheduled validation and manual workflow dispatch for prod-readiness checks.

## Why
- Workflow-only PRs currently match .github/workflows/*.yml and accidentally dispatch all 21 batch workflows after merge.
- Expensive full validation should be deliberate: scheduled weekly or manually before promotion.

## Validation
- ruby YAML parse for test-all-packages-orchestrator.yml
- actionlint -shellcheck= .github/workflows/test-all-packages-orchestrator.yml
- git diff --check