### PR TITLE
Harden GitHub tag lookups in regression tests

### DIFF
--- a/.github/workflows/test-greenplum.yml
+++ b/.github/workflows/test-greenplum.yml
@@ -81,6 +81,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       GREENPLUMPYTHON_BASELINE_TAG: "1.0.0-beta"
+      GH_TOKEN: ${{ github.token }}
 
     outputs:
       contract_version: "2.0"
@@ -244,15 +245,33 @@ jobs:
           import json
           import os
           import re
+          import sys
+          import time
           import urllib.request
 
           current = os.environ.get("CURRENT", "").lstrip("vV")
-          tags = json.load(
-              urllib.request.urlopen(
-                  "https://api.github.com/repos/greenplum-db/GreenplumPython-archive/tags?per_page=100",
-                  timeout=20,
-              )
-          )
+          url = "https://api.github.com/repos/greenplum-db/GreenplumPython-archive/tags?per_page=100"
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+          if token:
+              headers["Authorization"] = f"Bearer {token}"
+
+          last_error = None
+          for attempt in range(5):
+              try:
+                  request = urllib.request.Request(url, headers=headers)
+                  with urllib.request.urlopen(request, timeout=30) as response:
+                      tags = json.load(response)
+                  break
+              except Exception as exc:
+                  last_error = exc
+                  if attempt == 4:
+                      print(f"GitHub tag lookup failed after retries: {last_error}", file=sys.stderr)
+                      raise
+                  time.sleep(2 * (attempt + 1))
 
           stable_versions = sorted(
               {

--- a/.github/workflows/test-psmc.yml
+++ b/.github/workflows/test-psmc.yml
@@ -81,6 +81,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       PSMC_VERSION: "0.6.5"
+      GH_TOKEN: ${{ github.token }}
 
     outputs:
       contract_version: "2.0"
@@ -151,8 +152,10 @@ jobs:
           EMBEDDED=$(sed -n 's/^#define PSMC_VERSION "\(.*\)"/\1/p' "$BASE_DIR/cli.c" | head -n 1)
           NEXT_TAG=$(python3 - "${PSMC_VERSION}" <<'PY'
           import json
+          import os
           import re
           import sys
+          import time
           import urllib.request
 
           current = (sys.argv[1] or "").strip()
@@ -160,7 +163,29 @@ jobs:
               print("")
               raise SystemExit(0)
 
-          tags = json.loads(urllib.request.urlopen("https://api.github.com/repos/lh3/psmc/tags?per_page=100", timeout=20).read().decode("utf-8"))
+          url = "https://api.github.com/repos/lh3/psmc/tags?per_page=100"
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+          if token:
+              headers["Authorization"] = f"Bearer {token}"
+
+          last_error = None
+          for attempt in range(5):
+              try:
+                  request = urllib.request.Request(url, headers=headers)
+                  with urllib.request.urlopen(request, timeout=30) as response:
+                      tags = json.loads(response.read().decode("utf-8"))
+                  break
+              except Exception as exc:
+                  last_error = exc
+                  if attempt == 4:
+                      print(f"GitHub tag lookup failed after retries: {last_error}", file=sys.stderr)
+                      raise
+                  time.sleep(2 * (attempt + 1))
+
           versions = set()
           for tag in tags:
               name = (tag.get("name") or "").strip()


### PR DESCRIPTION
## Summary
- add the workflow GitHub token to GreenplumPython and PSMC regression jobs
- use authenticated GitHub API tag lookups with short retries
- keep package test behavior unchanged while avoiding transient public API rate-limit failures

## Validation
- ruby YAML parse for both workflows
- actionlint -shellcheck= for both workflows
- git diff --check