### PR TITLE
Retry startup-failed batch runs in orchestrator

### DIFF
--- a/.github/workflows/test-all-packages-orchestrator.yml
+++ b/.github/workflows/test-all-packages-orchestrator.yml
@@ -29,7 +29,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          echo "start_time=$START_TIME" >> $GITHUB_OUTPUT
+          echo "start_time=$START_TIME" >> "$GITHUB_OUTPUT"
 
           echo "🚀 Triggering batches 1 through 21..."
           for i in {1..21}; do
@@ -65,21 +65,44 @@ jobs:
           START_TIME="${{ steps.trigger.outputs.start_time }}"
           echo "⏳ Waiting for batches triggered after $START_TIME..."
 
-          BATCH_RUN_IDS=()
+          declare -A BATCH_RUN_IDS
+          declare -A BATCH_RETRIES
           MISSING_WORKFLOWS=()
+          MAX_STARTUP_RETRIES=3
           sleep 15
+
+          find_run_id() {
+            local workflow="$1"
+            local since="$2"
+            gh run list \
+              --workflow "$workflow" \
+              --branch "${{ github.ref_name }}" \
+              --json databaseId,createdAt \
+              --limit 100 \
+              --jq ".[] | select(.createdAt >= \"$since\") | .databaseId" | head -n 1
+          }
+
+          dispatch_batch() {
+            local workflow="$1"
+            local n=0
+            until [ $n -ge 5 ]
+            do
+              if gh workflow run "$workflow" --ref "${{ github.ref_name }}"; then
+                return 0
+              fi
+              n=$((n+1))
+              echo "Failed to trigger $workflow (attempt $n/5). Retrying in 5s..."
+              sleep 5
+            done
+            return 1
+          }
 
           for i in {1..21}; do
             WORKFLOW="test-all-packages-batch${i}.yml"
             RUN_ID=""
 
             for attempt in {1..12}; do
-              RUN_ID=$(gh run list \
-                --workflow "$WORKFLOW" \
-                --branch "${{ github.ref_name }}" \
-                --json databaseId,createdAt \
-                --limit 100 \
-                --jq ".[] | select(.createdAt >= \"$START_TIME\") | .databaseId" | head -n 1)
+              RUN_ID=$(find_run_id "$WORKFLOW" "$START_TIME")
 
               if [ -n "$RUN_ID" ]; then
                 break
@@ -94,7 +117,8 @@ jobs:
               MISSING_WORKFLOWS+=("$WORKFLOW")
             else
               echo "✅ Tracking $WORKFLOW (Run ID: $RUN_ID)"
-              BATCH_RUN_IDS+=("$RUN_ID")
+              BATCH_RUN_IDS[$i]="$RUN_ID"
+              BATCH_RETRIES[$i]=0
             fi
           done
 
@@ -106,14 +130,62 @@ jobs:
 
           while true; do
             STILL_RUNNING=0
-            for RID in "${BATCH_RUN_IDS[@]}"; do
-              STATUS=$(gh run view "$RID" --json status --jq .status)
+            FAILED_BATCHES=()
+
+            for i in {1..21}; do
+              WORKFLOW="test-all-packages-batch${i}.yml"
+              RID="${BATCH_RUN_IDS[$i]}"
+              RUN_STATE=$(gh run view "$RID" --json status,conclusion --jq '[.status, (.conclusion // "")] | @tsv')
+              read -r STATUS CONCLUSION <<< "$RUN_STATE"
+
               if [[ "$STATUS" != "completed" ]]; then
                 STILL_RUNNING=$((STILL_RUNNING + 1))
+                continue
+              fi
+
+              if [[ "$CONCLUSION" == "startup_failure" && "${BATCH_RETRIES[$i]}" -lt "$MAX_STARTUP_RETRIES" ]]; then
+                NEXT_RETRY=$((BATCH_RETRIES[$i] + 1))
+                RETRY_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+                echo "Batch $i hit startup_failure in run $RID. Re-dispatching $WORKFLOW (retry $NEXT_RETRY/$MAX_STARTUP_RETRIES)..."
+
+                if ! dispatch_batch "$WORKFLOW"; then
+                  FAILED_BATCHES+=("$WORKFLOW run $RID concluded startup_failure; retry dispatch failed")
+                  continue
+                fi
+
+                NEW_RUN_ID=""
+                for attempt in {1..12}; do
+                  NEW_RUN_ID=$(find_run_id "$WORKFLOW" "$RETRY_START")
+                  if [ -n "$NEW_RUN_ID" ]; then
+                    break
+                  fi
+                  echo "Waiting for retry run registration for $WORKFLOW (attempt $attempt/12)..."
+                  sleep 10
+                done
+
+                if [ -z "$NEW_RUN_ID" ]; then
+                  FAILED_BATCHES+=("$WORKFLOW run $RID concluded startup_failure; retry run was not registered")
+                  continue
+                fi
+
+                BATCH_RUN_IDS[$i]="$NEW_RUN_ID"
+                BATCH_RETRIES[$i]="$NEXT_RETRY"
+                STILL_RUNNING=$((STILL_RUNNING + 1))
+                echo "Tracking retry for $WORKFLOW (Run ID: $NEW_RUN_ID)"
+                continue
+              fi
+
+              if [[ "$CONCLUSION" != "success" ]]; then
+                FAILED_BATCHES+=("$WORKFLOW run $RID concluded ${CONCLUSION:-unknown}")
               fi
             done
 
             if [ "$STILL_RUNNING" -eq 0 ]; then
+              if [ "${#FAILED_BATCHES[@]}" -gt 0 ]; then
+                echo "❌ One or more batches did not complete successfully:"
+                printf ' - %s\n' "${FAILED_BATCHES[@]}"
+                exit 1
+              fi
               echo "🎉 All batches completed!"
               break
             fi
@@ -126,7 +198,48 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "🏁 All batches finished. Triggering Global Summary..."
+          SUMMARY_START=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           gh workflow run test-all-packages-summary.yml \
             --ref "${{ github.ref_name }}" \
             -f start_time="${{ steps.trigger.outputs.start_time }}" \
             -f triggering_batch=orchestrator
+
+          SUMMARY_RUN_ID=""
+          for attempt in {1..12}; do
+            SUMMARY_RUN_ID=$(gh run list \
+              --workflow test-all-packages-summary.yml \
+              --branch "${{ github.ref_name }}" \
+              --json databaseId,createdAt \
+              --limit 50 \
+              --jq ".[] | select(.createdAt >= \"$SUMMARY_START\") | .databaseId" | head -n 1)
+
+            if [ -n "$SUMMARY_RUN_ID" ]; then
+              break
+            fi
+
+            echo "Waiting for Global Summary run registration (attempt $attempt/12)..."
+            sleep 10
+          done
+
+          if [ -z "$SUMMARY_RUN_ID" ]; then
+            echo "❌ Error: Could not find Global Summary run after dispatch."
+            exit 1
+          fi
+
+          echo "Tracking Global Summary run $SUMMARY_RUN_ID..."
+          while true; do
+            RUN_STATE=$(gh run view "$SUMMARY_RUN_ID" --json status,conclusion --jq '[.status, (.conclusion // "")] | @tsv')
+            read -r STATUS CONCLUSION <<< "$RUN_STATE"
+
+            if [[ "$STATUS" == "completed" ]]; then
+              if [[ "$CONCLUSION" != "success" ]]; then
+                echo "❌ Global Summary run $SUMMARY_RUN_ID concluded ${CONCLUSION:-unknown}."
+                exit 1
+              fi
+              echo "✅ Global Summary completed successfully."
+              break
+            fi
+
+            echo "Global Summary is still $STATUS. Checking again in 30 seconds..."
+            sleep 30
+          done


### PR DESCRIPTION
## Summary
- retry batch runs that complete with GitHub Actions `startup_failure`
- redispatch only the affected batch and track the replacement run id
- fail the orchestrator on any non-success batch conclusion after retries
- wait for the Global Summary workflow and fail if it does not finish successfully

## Why
Batches 10, 11, and 12 began returning `startup_failure` with no jobs created even though the workflow files did not change between the last good July 29 run and the first bad August 1 run. These are GitHub Actions startup/scheduling failures, not package-test failures, so the orchestrator should heal them and should not let failed batch conclusions flow into the summary unnoticed.

## Validation
- ruby YAML parse
- actionlint with shellcheck enabled
- git diff --check