### PR TITLE
Grant actions read to reusable batch callers

### DIFF
--- a/.github/workflows/test-all-packages-batch10.yml
+++ b/.github/workflows/test-all-packages-batch10.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
 
   test-kubewarden-controller:

--- a/.github/workflows/test-all-packages-batch11.yml
+++ b/.github/workflows/test-all-packages-batch11.yml
@@ -4,6 +4,10 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
 
   test-sentry-javascript:

--- a/.github/workflows/test-all-packages-batch12.yml
+++ b/.github/workflows/test-all-packages-batch12.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
 
   test-dav1d:


### PR DESCRIPTION
## Summary
- add explicit caller permissions to batch 10, 11, and 12
- grant only `contents: read` and `actions: read`

## Why
GitHub startup annotations show these batches are invalid because nested reusable jobs request `actions: read` while the batch caller allows `actions: none`:

- Batch 10: `test-spdk` requested `actions: read`
- Batch 11: `test-sentry-javascript` requested `actions: read`
- Batch 12: `test-dav1d` requested `actions: read`

This is why the runs complete as `startup_failure` before any jobs/logs are created.

## Validation
- ruby YAML parse for batch 10/11/12
- actionlint with shellcheck enabled for batch 10/11/12
- git diff --check