### PR TITLE
Fix Torchtune Arm64 dependency compatibility

### DIFF
--- a/.github/workflows/test-torchtune.yml
+++ b/.github/workflows/test-torchtune.yml
@@ -76,6 +76,11 @@ on:
 jobs:
   test-torchtune:
     runs-on: ubuntu-24.04-arm
+    env:
+      TORCH_VERSION: '2.6.0'
+      TORCHVISION_VERSION: '0.21.0'
+      TORCHAO_VERSION: '0.10.0'
+      TORCHTUNE_VERSION: '0.6.1'
 
     outputs:
       contract_version: "2.0"
@@ -118,7 +123,13 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           python3 -m pip install --upgrade pip
-          python3 -m pip install torch torchtune torchao
+          # torchtune 0.6.1 imports APIs removed from torchao 0.18.0.
+          # Keep the PyTorch ecosystem packages on their tested release set.
+          python3 -m pip install \
+            "torch==$TORCH_VERSION" \
+            "torchvision==$TORCHVISION_VERSION" \
+            "torchao==$TORCHAO_VERSION" \
+            "torchtune==$TORCHTUNE_VERSION"
           echo "$PWD/venv/bin" >> "$GITHUB_PATH"
           echo "VIRTUAL_ENV=$PWD/venv" >> "$GITHUB_ENV"
           echo "install_status=success" >> "$GITHUB_OUTPUT"
@@ -167,7 +178,24 @@ jobs:
         run: |
           source "$VIRTUAL_ENV/bin/activate"
           START_TIME=$(date +%s)
-          if python3 -m pip show torchtune >/dev/null 2>&1 && python3 -m pip show torchao >/dev/null 2>&1; then
+          if python3 -m pip check && python3 - <<'PY'
+          import importlib.metadata
+          import os
+
+          expected = {
+              "torch": os.environ["TORCH_VERSION"],
+              "torchvision": os.environ["TORCHVISION_VERSION"],
+              "torchao": os.environ["TORCHAO_VERSION"],
+              "torchtune": os.environ["TORCHTUNE_VERSION"],
+          }
+          installed = {
+              package: importlib.metadata.version(package)
+              for package in expected
+          }
+          print(installed)
+          assert installed == expected
+          PY
+          then
             echo "status=passed" >> "$GITHUB_OUTPUT"
           else
             echo "status=failed" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Pins torchtune 0.6.1 to the compatible PyTorch 2.6.0, torchvision 0.21.0, and torchao 0.10.0 release set. The prior unpinned install selected torchao 0.18.0, which removed torchao.dtypes.nf4tensor and caused three real baseline failures. Test 3 now verifies exact package metadata plus pip dependency consistency. Native Arm64 validation is green: https://github.com/ArmDeveloperEcosystem/ecosystem-dashboard-for-arm/actions/runs/30986197466