### PR TITLE
Use supported Kafka candidate release

### DIFF
--- a/.github/workflows/test-kafka-connect.yml
+++ b/.github/workflows/test-kafka-connect.yml
@@ -70,7 +70,7 @@ jobs:
           package_name: Kafka Connect
           kind: kafka-connect
           baseline_version: 4.1.2
-          candidate_version: 4.2.0
+          candidate_version: 4.2.1
       - name: "Test 1 - Download Kafka baseline distribution"
         if: ${{ always() && (steps.smoke.outputs.test1_status == 'passed' || steps.smoke.outputs.test1_status == 'failed') }}
         shell: bash

--- a/.github/workflows/test-kafka-mirrormaker.yml
+++ b/.github/workflows/test-kafka-mirrormaker.yml
@@ -70,7 +70,7 @@ jobs:
           package_name: Kafka MirrorMaker
           kind: kafka-mirrormaker
           baseline_version: 4.1.2
-          candidate_version: 4.2.0
+          candidate_version: 4.2.1
       - name: "Test 1 - Download Kafka baseline distribution"
         if: ${{ always() && (steps.smoke.outputs.test1_status == 'passed' || steps.smoke.outputs.test1_status == 'failed') }}
         shell: bash


### PR DESCRIPTION
## Summary

- update Kafka Connect and Kafka MirrorMaker regression candidates from archived `4.2.0` to supported `4.2.1`
- keep Tests 1-5 strict and preserve the real Test 6 candidate download, extraction, and component-script validation

## Root cause

The full package sweep exposed a real Batch 21 failure. Kafka `4.2.0` has moved from Apache's active mirrors to the archive, and the GitHub Arm64 runner exhausted the fallback retries while connecting to the archive. The workflow did not fake a pass or skip the regression check.

## Validation

- `actionlint` and `git diff --check`: passed
- AWS native Arm64: official Kafka `4.2.1` archive downloaded, SHA-512 verified, extracted, and both component scripts confirmed executable
- Kafka Connect native GitHub Arm64 run: https://github.com/ArmDeveloperEcosystem/ecosystem-dashboard-for-arm/actions/runs/30988053548
- Kafka MirrorMaker native GitHub Arm64 run: https://github.com/ArmDeveloperEcosystem/ecosystem-dashboard-for-arm/actions/runs/30988057883
